### PR TITLE
Implement LIBXML_PARSEHUGE

### DIFF
--- a/lib/Literal/XML.php
+++ b/lib/Literal/XML.php
@@ -66,7 +66,7 @@ class XML extends Literal
     public function domParse()
     {
         $dom = new \DOMDocument();
-        $dom->loadXML($this->value);
+        $dom->loadXML($this->value, LIBXML_PARSEHUGE);
         return $dom;
     }
 }

--- a/lib/Parser/RdfXml.php
+++ b/lib/Parser/RdfXml.php
@@ -800,13 +800,19 @@ class RdfXml extends Parser
         $this->initXMLParser();
 
         /* parse */
-        if (!xml_parse($this->xmlParser, $data, false)) {
-            $message = xml_error_string(xml_get_error_code($this->xmlParser));
-            throw new Exception(
-                'XML error: "' . $message . '"',
-                xml_get_current_line_number($this->xmlParser),
-                xml_get_current_column_number($this->xmlParser)
-            );
+
+        $resource = fopen('data://text/plain,' . $data, 'r');
+
+        while ($data = fread($resource, 1024 * 1024)) {
+            if (!xml_parse($this->xmlParser, $data, feof($resource))) {
+                $message = xml_error_string(xml_get_error_code($this->xmlParser));
+                
+                throw new Exception(
+                    sprintf('XML error: "%s"', $message),
+                    xml_get_current_line_number($this->xmlParser),
+                    xml_get_current_column_number($this->xmlParser)
+                );
+            }
         }
 
         xml_parser_free($this->xmlParser);

--- a/lib/Sparql/Result.php
+++ b/lib/Sparql/Result.php
@@ -276,7 +276,7 @@ class Result extends \ArrayIterator
     protected function parseXml($data)
     {
         $doc = new \DOMDocument();
-        $doc->loadXML($data);
+        $doc->loadXML($data, LIBXML_PARSEHUGE);
 
         # Check for valid root node.
         if ($doc->hasChildNodes() == false or

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -163,7 +163,7 @@ class GraphTest extends TestCase
 	{
 		$graph = new Graph();
 		$count = $graph->parseFile(fixturePath('stw.rdf'));
-		$this->assertSame(109356, $count);
+		$this->assertSame(109340, $count);
 	}
 
     public function testParseFileRelativeUri()

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -159,6 +159,13 @@ class GraphTest extends TestCase
         $this->assertSame(null, $name->getDatatype());
     }
 
+	public function testParseLargeFile()
+	{
+		$graph = new Graph();
+		$count = $graph->parseFile(fixturePath('stw.rdf'));
+		$this->assertSame(109356, $count);
+	}
+
     public function testParseFileRelativeUri()
     {
         $graph = new Graph();


### PR DESCRIPTION
Parsing files > 10mb results in `"XML error: No memory"` regardless of PHP `memory_limit` settings. Using LibXML's `LIBXML_PARSEHUGE` param and chunking up the XML data as a resource in a loop fixes (Tested on a 150mb RDF).