### PR TITLE
fix: check that local part of qnames is valid XML in turtle serialisation

### DIFF
--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -340,8 +340,8 @@ class RdfNamespace
 
             $local_part = substr($uri, strlen($long));
 
-            if (strpos($local_part, '/') !== false) {
-                // we can't have '/' in local part
+            // check that local part only contains valid QName characters
+            if (!self::isValidXMLUriPart($local_part)) {
                 continue;
             }
 
@@ -428,5 +428,36 @@ class RdfNamespace
         }
 
         return $shortUri;
+    }
+
+    /**
+     * Check if a local or prefix portion of URI is valid XML
+     * 
+     * This check is based on the XML specification
+     * 
+     * prefix        ::= Name minus ":"                   // see: http://www.w3.org/TR/REC-xml-names/#NT-NCName
+     * Name          ::= NameStartChar (NameChar)*        // see: http://www.w3.org/TR/REC-xml/#NT-Name
+     * NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] |
+     *                   [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] |
+     *                   [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
+     * NameChar      ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
+     *
+     * @param string $uri
+     * @return boolean
+     */
+    public static function isValidXMLUriPart(string $uri)
+    {
+        $_name_start_char = 
+            'A-Z_a-z\x{C0}-\x{D6}\x{D8}-\x{F6}\x{F8}-\x{2FF}\x{370}-\x{37D}\x{37F}-\x{1FFF}' .
+            '\x{200C}-\x{200D}\x{2070}-\x{218F}\x{2C00}-\x{2FEF}\x{3001}-\x{D7FF}\x{F900}-\x{FDCF}' . 
+            '\x{FDF0}-\x{FFFD}\x{10000}-\x{EFFFF}';
+        
+        $_namechar = 
+            $_name_start_char .
+            '\-\.0-9\x{B7}\x{0300}-\x{036F}\x{203F}-\x{2040}';
+
+        $regex = "/^[$_name_start_char][$_namechar]*\$/u";
+
+        return (bool) preg_match($regex, $uri);
     }
 }


### PR DESCRIPTION
When serializing something like: http://example.com/test?query=1234

This was be incorrectly serialized into turtle and XML as something like "ex:test?query=1234" however this isn't a valid shortened Qname.  The turtle parser can also not re-expand this qname and it causes problems when the serialized output is being read in by another parser implementation (for example N3.js)

fixes https://github.com/njh/easyrdf/issues/262

ref XML spec for qnames: https://www.w3.org/TR/REC-xml-names/#NT-QName