### PR TITLE
increase timeout in lib/Http/Client to avoid failing tests because of connection refusal

### DIFF
--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -59,7 +59,7 @@ class Client
     private $config = array(
         'maxredirects'    => 5,
         'useragent'       => 'EasyRdf HTTP Client',
-        'timeout'         => 10
+        'timeout'         => 30
     );
 
     /**


### PR DESCRIPTION
Timeout increase from 10 to 30. I saw a decrease in failing tests. Nevertheless, it might be better to avoid real time HTTP calls during tests and switch to mocks.

Further information on this: https://github.com/sweetyrdf/easyrdf/issues/7

Original PR: https://github.com/sweetyrdf/easyrdf/pull/13/files