### PR TITLE
Fixes "Sparql\Client uses invalid parameters for Zend\Http\Client->setHeaders"

### DIFF
--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -462,6 +462,79 @@ class ClientTest extends TestCase
         $this->assertContains('text/turtle', $types);
     }
 
+    /**
+     * Test for issue https://github.com/sweetyrdf/easyrdf/issues/9
+     *
+     * Sparql\Client calls $client->setHeaders with a name-value pair, regardless of
+     * whether $client is of type EasyRdf\Http\Client or Zend\Http\Client.
+     */
+    public function testIssue9EasyRdfHttpClient()
+    {
+        /*
+         * setup mocks
+         */
+        // response
+        $response = $this->getMockBuilder(\EasyRdf\Http\Response::class)->disableOriginalConstructor()->getMock();
+        $response->method('getStatus')->willReturn(204); // no content
+        $response->method('isSuccessful')->willReturn(true);
+
+        // client
+        $easyRdfHttpClient = $this->getMockBuilder(\EasyRdf\Http\Client::class)->disableOriginalConstructor()->getMock();
+        $easyRdfHttpClient->method('request')->willReturn($response);
+        $easyRdfHttpClient
+            ->expects($this->exactly(1))
+            ->method('setHeaders')
+            // we only check first parameter, which has to be 'Accept'
+            ->with($this->callback(function ($firstParam) {
+                return 'Accept' == $firstParam;
+            }));
+
+        Http::setDefaultHttpClient($easyRdfHttpClient);
+
+        $this->sparql = new Client('http://localhost:8080/sparql');
+
+        $this->sparql->query('test');
+    }
+
+    /**
+     * Test for issue https://github.com/sweetyrdf/easyrdf/issues/9
+     *
+     * Sparql\Client calls $client->setHeaders with a name-value pair, regardless of
+     * whether $client is of type EasyRdf\Http\Client or Zend\Http\Client.
+     */
+    public function testIssue9ZendHttpClient()
+    {
+        /*
+         * setup mocks
+         */
+        // response
+        $response = $this->getMockBuilder(\EasyRdf\Http\Response::class)->disableOriginalConstructor()->getMock();
+        $response->method('getStatus')->willReturn(204); // no content
+        $response->method('isSuccessful')->willReturn(true);
+
+        // client
+        $easyRdfHttpClient = $this->getMockBuilder(\Zend\Http\Client::class)->disableOriginalConstructor()->getMock();
+        $easyRdfHttpClient->method('send')->willReturn($response);
+        $easyRdfHttpClient
+            ->expects($this->exactly(1))
+            ->method('setHeaders')
+            /*
+             * we only check if an array with 'Accept' as key was given. ignore the value, because it may vary between PHP versions.
+             * FYI: https://github.com/sweetyrdf/easyrdf/pull/10/commits/aab3af54aa0064203f61f0046f0e16cafaeacdc7
+             */
+            ->with($this->callback(function ($acceptHeaders) {
+                return \is_array($acceptHeaders)
+                    && isset($acceptHeaders['Accept'])
+                    && 1 == \count($acceptHeaders);
+            }));
+
+        Http::setDefaultHttpClient($easyRdfHttpClient);
+
+        $this->sparql = new Client('http://localhost:8080/sparql');
+
+        $this->sparql->query('test');
+    }
+
     private static function parseAcceptHeader($accept_str)
     {
         $types = array();

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -463,12 +463,12 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Test for issue https://github.com/sweetyrdf/easyrdf/issues/9
+     * Test for issue https://github.com/easyrdf/easyrdf/issues/305
      *
      * Sparql\Client calls $client->setHeaders with a name-value pair, regardless of
      * whether $client is of type EasyRdf\Http\Client or Zend\Http\Client.
      */
-    public function testIssue9EasyRdfHttpClient()
+    public function testIssue305EasyRdfHttpClient()
     {
         /*
          * setup mocks
@@ -499,12 +499,12 @@ class ClientTest extends TestCase
     }
 
     /**
-     * Test for issue https://github.com/sweetyrdf/easyrdf/issues/9
+     * Test for issue https://github.com/easyrdf/easyrdf/issues/305
      *
      * Sparql\Client calls $client->setHeaders with a name-value pair, regardless of
      * whether $client is of type EasyRdf\Http\Client or Zend\Http\Client.
      */
-    public function testIssue9ZendHttpClient()
+    public function testIssue305ZendHttpClient()
     {
         /*
          * setup mocks
@@ -523,7 +523,6 @@ class ClientTest extends TestCase
             /*
              * we only check if an array with 'Accept' as key was given. ignore the value,
              * because it may vary between PHP versions.
-             * FYI: https://github.com/sweetyrdf/easyrdf/pull/10/commits/aab3af54aa0064203f61f0046f0e16cafaeacdc7
              */
             ->with($this->callback(function ($acceptHeaders) {
                 return \is_array($acceptHeaders)

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -521,7 +521,7 @@ class ClientTest extends TestCase
             ->expects($this->exactly(1))
             ->method('setHeaders')
             /*
-             * we only check if an array with 'Accept' as key was given. ignore the value, 
+             * we only check if an array with 'Accept' as key was given. ignore the value,
              * because it may vary between PHP versions.
              * FYI: https://github.com/sweetyrdf/easyrdf/pull/10/commits/aab3af54aa0064203f61f0046f0e16cafaeacdc7
              */

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -479,7 +479,9 @@ class ClientTest extends TestCase
         $response->method('isSuccessful')->willReturn(true);
 
         // client
-        $easyRdfHttpClient = $this->getMockBuilder(\EasyRdf\Http\Client::class)->disableOriginalConstructor()->getMock();
+        $easyRdfHttpClient = $this->getMockBuilder(\EasyRdf\Http\Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $easyRdfHttpClient->method('request')->willReturn($response);
         $easyRdfHttpClient
             ->expects($this->exactly(1))
@@ -519,7 +521,8 @@ class ClientTest extends TestCase
             ->expects($this->exactly(1))
             ->method('setHeaders')
             /*
-             * we only check if an array with 'Accept' as key was given. ignore the value, because it may vary between PHP versions.
+             * we only check if an array with 'Accept' as key was given. ignore the value, 
+             * because it may vary between PHP versions.
              * FYI: https://github.com/sweetyrdf/easyrdf/pull/10/commits/aab3af54aa0064203f61f0046f0e16cafaeacdc7
              */
             ->with($this->callback(function ($acceptHeaders) {


### PR DESCRIPTION
It fixes the problem by using a proxy function, which uses a different function call (send or request) based on the client class.

Fixes #305

Ref:
* https://github.com/sweetyrdf/easyrdf/pull/10
* https://github.com/sweetyrdf/easyrdf/issues/9