### PR TITLE
N-Triple and Turtle parser and serialiser fixes (encoding unicode, escaping IRIs and literals, some performance tweaks)

### DIFF
--- a/lib/Parser/Ntriples.php
+++ b/lib/Parser/Ntriples.php
@@ -213,7 +213,8 @@ class Ntriples extends Parser
         foreach ($lines as $index => $line) {
             $lineNum = $index + 1;
 
-            $regex = '/^\s*(.+?)\s+<([^<>]+?)>\s+(<[^>]+>|_:[^\s]*|"(\\\\"|[^"])*")(\\^\\^<[^>]+>)?(@[-a-zA-Z0-9]+)?\s*\./';
+            $regex = '/^\s*(.+?)\s+<([^<>]+?)>\s+(<[^>]+>|_:[^\s]*|"(\\\\"|[^"])*")'
+                .'(\\^\\^<[^>]+>)?(@[-a-zA-Z0-9]+)?\s*\./';
             $pregResult2 = preg_match($regex, $line, $matches);
 
             if (preg_match('/^\s*#/', $line)) {

--- a/lib/Parser/Ntriples.php
+++ b/lib/Parser/Ntriples.php
@@ -80,10 +80,8 @@ class Ntriples extends Parser
             return $str;
         }
 
-        while (
-            preg_match('/\\\\U([0-9A-F]{8})/', $str, $matches) ||
-            preg_match('/\\\\u([0-9A-F]{4})/', $str, $matches)
-        ) {
+        while (preg_match('/\\\\U([0-9A-F]{8})/', $str, $matches)
+            || preg_match('/\\\\u([0-9A-F]{4})/', $str, $matches)) {
             //TODO - lines 87-105 can be replaced with mb_chr() in PHP >=7.2
             $no = hexdec($matches[1]);
             if ($no < 128) {                // 0x80
@@ -214,10 +212,14 @@ class Ntriples extends Parser
         $lines = preg_split('/\x0D?\x0A/', strval($data));
         foreach ($lines as $index => $line) {
             $lineNum = $index + 1;
+
+            $regex = '/^\s*(.+?)\s+<([^<>]+?)>\s+(<[^>]+>|_:[^\s]*|"(\\\\"|[^"])*")(\\^\\^<[^>]+>)?(@[-a-zA-Z0-9]+)?\s*\./';
+            $pregResult2 = preg_match($regex, $line, $matches);
+
             if (preg_match('/^\s*#/', $line)) {
                 # Comment
                 continue;
-            } elseif (preg_match('/^\s*(.+?)\s+<([^<>]+?)>\s+(<[^>]+>|_:[^\s]*|"(\\\\"|[^"])*")(\\^\\^<[^>]+>)?(@[-a-zA-Z0-9]+)?\s*\./', $line, $matches)) {
+            } elseif ($pregResult2) {
                 $this->addTriple(
                     $this->parseNtriplesSubject($matches[1], $lineNum),
                     $this->unescapeString($matches[2]),

--- a/lib/Parser/Ntriples.php
+++ b/lib/Parser/Ntriples.php
@@ -41,7 +41,7 @@ use EasyRdf\Graph;
 use EasyRdf\Parser;
 
 /**
- * A pure-php class to parse N-Triples with no dependancies.
+ * A pure-php class to parse N-Triples with no dependencies.
  *
  * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey

--- a/lib/Parser/Turtle.php
+++ b/lib/Parser/Turtle.php
@@ -795,7 +795,6 @@ class Turtle extends Ntriples
         if ($c == '.' || $c == 'e' || $c == 'E') {
             // read optional fractional digits
             if ($c == '.') {
-
                 if (self::isWhitespace($this->peek())) {
                     // We're parsing an integer that did not have a space before the
                     // period to end the statement

--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -56,7 +56,7 @@ class Ntriples extends Serialiser
      *
      * @var string[]
      */
-    static private $iriEscapeMap = array(
+    private static $iriEscapeMap = array(
         "<" => "\\u003C",
         ">" => "\\u003E",
         '"' => "\\u0022",
@@ -106,7 +106,7 @@ class Ntriples extends Serialiser
      * https://www.w3.org/TR/n-triples/#grammar-production-STRING_LITERAL_QUOTE
      * @var string[]
      */
-    static private $literalEscapeMap = array(
+    private static $literalEscapeMap = array(
         "\n" => '\\n',
         "\r" => '\\r',
         '"' => '\\"',

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -66,8 +66,7 @@ class Turtle extends Serialiser
      */
     public static function escapeIri($resourceIri)
     {
-        $escapedIri = str_replace('>', '\\>', $resourceIri);
-        return "<$escapedIri>";
+        return '<' . Ntriples::escapeIri($resourceIri) . '>';
     }
 
     /**
@@ -81,23 +80,7 @@ class Turtle extends Serialiser
      */
     public static function quotedString($value)
     {
-        if (preg_match('/[\t\n\r]/', $value)) {
-            $escaped = str_replace(array('\\', '"""'), array('\\\\', '\\"""'), $value);
-
-            // Check if the last character is a trailing double quote, if so, escape it.
-            $pos = strrpos($escaped, '"');
-
-            if ($pos !== false && $pos + 1 == strlen($escaped)) {
-                $escaped = substr($escaped, 0, -1);
-
-                $escaped .= '\"';
-            }
-
-            return '"""'.$escaped.'"""';
-        } else {
-            $escaped = str_replace(array('\\', '"'), array('\\\\', '\\"'), $value);
-            return '"'.$escaped.'"';
-        }
+        return '"' . Ntriples::escapeLiteral($value) . '"';
     }
 
     /**
@@ -181,8 +164,8 @@ class Turtle extends Serialiser
             return $this->serialiseLiteral($object);
         } else {
             throw new \InvalidArgumentException(
-                "serialiseObject() requires \$object to be ".
-                'of type EasyRdf\Resource or EasyRdf\Literal'
+                "serialiseObject() requires \$object to be " .
+                    'of type EasyRdf\Resource or EasyRdf\Literal'
             );
         }
     }
@@ -212,7 +195,7 @@ class Turtle extends Serialiser
                 if ($count) {
                     $turtle .= "\n$indent  $serialised";
                 } else {
-                    $turtle .= " ".$serialised;
+                    $turtle .= " " . $serialised;
                 }
             }
         }
@@ -231,7 +214,7 @@ class Turtle extends Serialiser
     protected function serialiseProperties($res, $depth = 1)
     {
         $properties = $res->propertyUris();
-        $indent = str_repeat(' ', ($depth*2)-1);
+        $indent = str_repeat(' ', ($depth * 2) - 1);
 
         $turtle = '';
         if (count($properties) > 1) {
@@ -267,7 +250,7 @@ class Turtle extends Serialiser
                         // Nested unlabelled Blank Node
                         $this->outputtedBnodes[$id] = true;
                         $turtle .= ' [';
-                        $turtle .= $this->serialiseProperties($object, $depth+1);
+                        $turtle .= $this->serialiseProperties($object, $depth + 1);
                         $turtle .= ' ]';
                     } else {
                         // Multiple properties pointing to this blank node
@@ -287,7 +270,7 @@ class Turtle extends Serialiser
                 $turtle .= "\n";
             }
         } elseif ($pCount > 1) {
-            $turtle .= "\n" . str_repeat(' ', (($depth-1)*2)-1);
+            $turtle .= "\n" . str_repeat(' ', (($depth - 1) * 2) - 1);
         }
 
         return $turtle;

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -324,7 +324,7 @@ class GraphTest extends TestCase
             array('callback' => $checkRequest)
         );
         $graph = new Graph();
-        $this->assertSame(15, $graph->load('http://www.example.com/', 'application/x-turtle'));
+        $this->assertSame(14, $graph->load('http://www.example.com/', 'application/x-turtle'));
     }
 
     public function testLoadWithContentTypeAndCharset()
@@ -336,7 +336,7 @@ class GraphTest extends TestCase
             array('headers' => array('Content-Type' => 'text/plain; charset=utf8'))
         );
         $graph = new Graph('http://www.example.com/');
-        $this->assertSame(14, $graph->load());
+        $this->assertSame(15, $graph->load());
         $this->assertStringEquals(
             'Joe Bloggs',
             $graph->get('http://www.example.com/joe#me', 'foaf:name')

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -324,7 +324,7 @@ class GraphTest extends TestCase
             array('callback' => $checkRequest)
         );
         $graph = new Graph();
-        $this->assertSame(14, $graph->load('http://www.example.com/', 'application/x-turtle'));
+        $this->assertSame(15, $graph->load('http://www.example.com/', 'application/x-turtle'));
     }
 
     public function testLoadWithContentTypeAndCharset()

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -363,7 +363,7 @@ class NtriplesTest extends TestCase
     {
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            'Failed to parse statement: on line 1'
+            'Failed to parse statement on line 1'
         );
         $this->parser->parse(
             $this->graph,

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -60,7 +60,7 @@ class NtriplesTest extends TestCase
     public function testParse()
     {
         $count = $this->parser->parse($this->graph, $this->nt_data, 'ntriples', null);
-        $this->assertSame(14, $count);
+        $this->assertSame(15, $count);
 
         $joe = $this->graph->resource('http://www.example.com/joe#me');
         $this->assertNotNull($joe);
@@ -363,7 +363,7 @@ class NtriplesTest extends TestCase
     {
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            'Failed to parse object: foobar on line 1'
+            'Failed to parse statement: on line 1'
         );
         $this->parser->parse(
             $this->graph,

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -90,7 +90,7 @@ class NtriplesArray extends Ntriples
                         $triples,
                         array(
                             's' => $this->serialiseResource($resource),
-                            'p' => "<" . $this->escapeString($property) . ">",
+                            'p' => "<" . $this->escapeIri($property) . ">",
                             'o' => $this->serialiseValue($value)
                         )
                     );

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -289,8 +289,8 @@ class NtriplesTest extends TestCase
     public function testIssue219Unicode()
     {
         $pairs = array(
-            '位' => '"\u4F4D"',
-            "Дуглас Адамс" => '"\u0414\u0443\u0433\u043B\u0430\u0441 \u0410\u0434\u0430\u043C\u0441"',
+            '位' => '"位"',
+            "Дуглас Адамс" => '"Дуглас Адамс"',
         );
 
         $serializer = new Ntriples();

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -74,7 +74,7 @@ class TurtleTest extends TestCase
     public function testEscapeIriAngleBracket()
     {
         $this->assertSame(
-            '<http://google.com/search?q=<\>>',
+            '<http://google.com/search?q=\u003C\u003E>',
             Turtle::escapeIri('http://google.com/search?q=<>')
         );
     }
@@ -90,7 +90,7 @@ class TurtleTest extends TestCase
     public function testMultilineQuotedString()
     {
         $this->assertSame(
-            '"""Hello	World"""',
+            '"Hello	World"',
             Turtle::quotedString('Hello	World')
         );
     }
@@ -126,7 +126,7 @@ class TurtleTest extends TestCase
     {
         $res = $this->graph->resource('http://google.com/search?q=<>');
         $this->assertSame(
-            '<http://google.com/search?q=<\>>',
+            '<http://google.com/search?q=\u003C\u003E>',
             $this->serialiser->serialiseResource($res)
         );
     }
@@ -144,7 +144,7 @@ class TurtleTest extends TestCase
     {
         $literal = new Literal("Hello\nWorld");
         $this->assertSame(
-            "\"\"\"Hello\nWorld\"\"\"",
+            "\"Hello\\nWorld\"",
             $this->serialiser->serialiseLiteral($literal)
         );
     }
@@ -516,8 +516,8 @@ class TurtleTest extends TestCase
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
-            "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n".
-            "<http://example.com/joe#me> foaf:name \"\"\"Line 1\nLine 2\"\"\" .\n",
+            "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n" .
+                "<http://example.com/joe#me> foaf:name \"Line 1\\nLine 2\" .\n",
             $turtle
         );
     }
@@ -525,12 +525,12 @@ class TurtleTest extends TestCase
     public function testSerialiseMultiLineEscaped2()
     {
         $joe = $this->graph->resource('http://example.com/joe#me');
-        $joe->set('foaf:name', "\t".'"""'."\t");
+        $joe->set('foaf:name', "\t" . '"""' . "\t");
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
-            "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n".
-            "<http://example.com/joe#me> foaf:name \"\"\"\t\\\"\"\"\t\"\"\" .\n",
+            "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n" .
+                "<http://example.com/joe#me> foaf:name \"\t\\\"\\\"\\\"\t\" .\n",
             $turtle
         );
     }
@@ -538,12 +538,12 @@ class TurtleTest extends TestCase
     public function testSerialiseMultiLineEscaped3()
     {
         $joe = $this->graph->resource('http://example.com/joe#me');
-        $joe->set('foaf:name', "\t".'""Doe"');
+        $joe->set('foaf:name', "\t" . '""Doe"');
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
-            "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n".
-            "<http://example.com/joe#me> foaf:name \"\"\"\t\"\"Doe\\\"\"\"\" .\n",
+            "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n" .
+                "<http://example.com/joe#me> foaf:name \"\t\\\"\\\"Doe\\\"\" .\n",
             $turtle
         );
     }

--- a/test/fixtures/foaf.nt
+++ b/test/fixtures/foaf.nt
@@ -1,6 +1,7 @@
 <http://www.example.com/joe/foaf.rdf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/PersonalProfileDocument> .
 <http://www.example.com/joe/foaf.rdf> <http://www.w3.org/2000/01/rdf-schema#label> "Joe Bloggs' FOAF File" .
-<http://www.example.com/joe/foaf.rdf> <http://xmlns.com/foaf/0.1/maker> <http://www.example.com/joe#me> .
+# full line comment
+<http://www.example.com/joe/foaf.rdf> <http://xmlns.com/foaf/0.1/maker> <http://www.example.com/joe#me> . # end of line comment
 <http://www.example.com/joe/foaf.rdf> <http://xmlns.com/foaf/0.1/primaryTopic> <http://www.example.com/joe#me> .
 <http://www.example.com/joe#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/title> "Mr" .
@@ -8,6 +9,7 @@
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/firstName> "Joe" .
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/family_name> "Bloggs" .
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/homepage> <http://www.example.com/joe/> .
+<http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 _:genid1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Project> .
 _:genid1 <http://xmlns.com/foaf/0.1/name> "Joe's Current Project" .
 _:genid1 <http://xmlns.com/foaf/0.1/homepage> <http://www.example.com/project> .


### PR DESCRIPTION
These changes were contributed by @zozlak on my fork: https://github.com/sweetyrdf/easyrdf/pull/11

**Quote from his pull request:**

* Ntriples serializer doesn't encode unicode characters any more (as they are valid and escaping them takes a lot of time and involves a lot of strings copying).
* Ntriples serializer applies different escaping rules to IRIs and literals (according to https://www.w3.org/TR/n-triples/#n-triples-grammar)
* Ntriples parser allows comments at the end of a line (as defined in https://www.w3.org/TR/n-triples/#n-triples-grammar)
* Turtle serializer simply uses Ntriples escape routine for escaping literals (which is perfectly valid and reduces the codebase)
* Turtle parser splits input into an array with `preg_split('//u', $data, null, PREG_SPLIT_NO_EMPTY);` which allows performant character position-based access to the parsed input. The previous implementation using `mb_substr()` was extremely slow for larger inputs.