### PR TITLE
fixes "The Graph::properties() and Resource::properties() methods don't handle properties in unknown namespaces correctly"

### DIFF
--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -1255,7 +1255,7 @@ class Graph
         $properties = array();
         if (isset($this->index[$resource])) {
             foreach ($this->index[$resource] as $property => $value) {
-                $short = RdfNamespace::shorten($property);
+                $short = RdfNamespace::shorten($property, true);
                 if ($short) {
                     $properties[] = $short;
                 }

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -1324,4 +1324,26 @@ class ResourceTest extends TestCase
         unset($this->resource['rdf:testMagicUnset']);
         $this->assertNull($this->resource->get('rdf:testMagicUnset'));
     }
+
+    /**
+     * @see https://github.com/sweetyrdf/easyrdf/issues/17
+     */
+    public function testPropertyUrisMatchProperties()
+    {
+        $g = new Graph();
+        $r = $g->resource('http://sample/resource');
+        $r->addLiteral('dc:title', 'sample title');
+        $r->addLiteral('http://unknown.namespace/property', 'sample value');
+
+        $uris = $r->propertyUris();
+        $props = $r->properties();
+        $this->assertEquals(count($uris), count($props));
+
+        sort($uris);
+        $exProps = array_map(function ($x) {
+            return RdfNamespace::expand($x);
+        }, $props);
+        sort($exProps);
+        $this->assertEquals($uris, $exProps);
+    }
 }


### PR DESCRIPTION
These changes were contributed by @zozlak on my fork:https://github.com/sweetyrdf/easyrdf/pull/18

Quote from his pull request:

> The problem is caused by https://github.com/easyrdf/easyrdf/blob/master/lib/Graph.php#L1256-L1259 which silently skips all properties within namespaces unknown to EasyRdf\RdfNamespace.