### PR TITLE
Add SPARQL client rawQuery() method

### DIFF
--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -48,11 +48,11 @@ use EasyRdf\Utils;
  * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
- *         
- *         
+ *
+ *
  *          ---- History
  *          2017-12-06 F. Michel - Add the queryRaw method
- *         
+ *
  */
 class Client
 {
@@ -419,10 +419,11 @@ class Client
      * @param string $usingNamedGraphUri
      *            Used as the using-named-graph-uri header
      * @return Http\Response the raw HTTP response
-     *        
+     *
      * @ignore
      */
-    public function queryRaw($query, $accept, $defaultGraphUri = null, $namedGraphUri = null, $usingGraphUri = null, $usingNamedGraphUri = null)
+    public function queryRaw($query, $accept, $defaultGraphUri = null,
+        $namedGraphUri = null, $usingGraphUri = null, $usingNamedGraphUri = null)
     {
         // Check for undefined prefixes
         $prefixes = '';
@@ -434,35 +435,40 @@ class Client
         
         $client = Http::getDefaultHttpClient();
         $client->resetParameters();
-
+        
         // Tell the server which response formats we can parse
         $client->setHeaders('Accept', $accept);
-
+        
         $encodedQuery = 'query=' . urlencode($prefixes . $query);
-
+        
         // In the "query via URL-encoded POST", the graph URIs are passed in the request message body
-        if ($defaultGraphUri)
+        if ($defaultGraphUri) {
             $encodedQuery = $encodedQuery . '&default-graph-uri=' . urlencode($defaultGraphUri);
-        if ($namedGraphUri)
+        }
+        if ($namedGraphUri) {
             $encodedQuery = $encodedQuery . '&named-graph-uri=' . urlencode($namedGraphUri);
-
-        if ($usingGraphUri)
+        }
+        
+        if ($usingGraphUri) {
             $encodedQuery = $encodedQuery . '&using-graph-uri=' . urlencode($usingGraphUri);
-        if ($usingNamedGraphUri)
+        }
+        if ($usingNamedGraphUri) {
             $encodedQuery = $encodedQuery . '&using-named-graph-uri=' . urlencode($usingNamedGraphUri);
-
+        }
+        
         $client->setUri($this->queryUri);
         $client->setMethod('POST');
         $client->setRawData($encodedQuery);
         $client->setHeaders('Content-Type', 'application/x-www-form-urlencoded');
-
+        
         $response = $client->request();
         if ($response->getStatus() == 204) {
             // No content
             return $response;
         } elseif ($response->isSuccessful()) {
             return $response;
-        } else
+        } else {
             throw new Exception("HTTP request for SPARQL query failed: " . $response->getBody());
+        }
     }
 }

--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -48,6 +48,11 @@ use EasyRdf\Utils;
  * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
+ *         
+ *         
+ *          ---- History
+ *          2017-12-06 F. Michel - Add the queryRaw method
+ *         
  */
 class Client
 {
@@ -269,6 +274,7 @@ class Client
         }
     }
 
+
     /**
      * Adds missing prefix-definitions to the query
      *
@@ -346,7 +352,7 @@ class Client
                 // both
                 $accept = Format::getHttpAcceptHeader($sparql_results_types);
             }
-
+            
             $client->setHeaders('Accept', $accept);
 
             $encodedQuery = 'query=' . urlencode($processed_query);
@@ -371,7 +377,7 @@ class Client
 
         return $client->request();
     }
-
+    
     /**
      * Parse HTTP-response object into a meaningful result-object.
      *
@@ -391,5 +397,72 @@ class Client
             $result = new Graph($this->queryUri, $response->getBody(), $content_type);
             return $result;
         }
+    }
+
+    /**
+     * This is a low-level version of the query() function where the Accept header is
+     * provided explicitely, as well as the default and named graphs URIs.
+     *
+     * The result is the body of the raw HTTP response, not an EasyRdf_Sparql_Result or
+     * EasyRdf_Graph like in function request().
+     *
+     * @param string $query
+     *            The query string to be executed
+     * @param string $accept
+     *            Gives the value of the Accept HTTP header
+     * @param string $defaultGraphUri
+     *            Used as the default-graph-uri header
+     * @param string $namedGraphUri
+     *            Used as the named-graph-uri header
+     * @param string $usingGraphUri
+     *            Used as the using-graph-uri header
+     * @param string $usingNamedGraphUri
+     *            Used as the using-named-graph-uri header
+     * @return Http\Response the raw HTTP response
+     *        
+     * @ignore
+     */
+    public function queryRaw($query, $accept, $defaultGraphUri = null, $namedGraphUri = null, $usingGraphUri = null, $usingNamedGraphUri = null)
+    {
+        // Check for undefined prefixes
+        $prefixes = '';
+        foreach (RdfNamespace::namespaces() as $prefix => $uri) {
+            if (strpos($query, "{$prefix}:") !== false and strpos($query, "PREFIX {$prefix}:") === false) {
+                $prefixes .= "PREFIX {$prefix}: <{$uri}>\n";
+            }
+        }
+        
+        $client = Http::getDefaultHttpClient();
+        $client->resetParameters();
+
+        // Tell the server which response formats we can parse
+        $client->setHeaders('Accept', $accept);
+
+        $encodedQuery = 'query=' . urlencode($prefixes . $query);
+
+        // In the "query via URL-encoded POST", the graph URIs are passed in the request message body
+        if ($defaultGraphUri)
+            $encodedQuery = $encodedQuery . '&default-graph-uri=' . urlencode($defaultGraphUri);
+        if ($namedGraphUri)
+            $encodedQuery = $encodedQuery . '&named-graph-uri=' . urlencode($namedGraphUri);
+
+        if ($usingGraphUri)
+            $encodedQuery = $encodedQuery . '&using-graph-uri=' . urlencode($usingGraphUri);
+        if ($usingNamedGraphUri)
+            $encodedQuery = $encodedQuery . '&using-named-graph-uri=' . urlencode($usingNamedGraphUri);
+
+        $client->setUri($this->queryUri);
+        $client->setMethod('POST');
+        $client->setRawData($encodedQuery);
+        $client->setHeaders('Content-Type', 'application/x-www-form-urlencoded');
+
+        $response = $client->request();
+        if ($response->getStatus() == 204) {
+            // No content
+            return $response;
+        } elseif ($response->isSuccessful()) {
+            return $response;
+        } else
+            throw new Exception("HTTP request for SPARQL query failed: " . $response->getBody());
     }
 }


### PR DESCRIPTION
Hi guys,

Second attempt for that PR, sorry about the mistake in the previous one.

So as I said before, I've made an update in the SPARQL client, that you may like to include in your project: I added a function queryRaw() that is a low-level version of the query() function: it takes as argument an Accept header, as well as the default and named graphs URIs to be passed as http parameters.

It provides applications with greater flexibility as to what they want to do.

Regards,
Franck.

PS: for some reason the Github diff shows differences in the whole file - although I took care of not changing code indentation. Maybe an issue with blanks. Anyway the only change is at the end.