### PR TITLE
Removed version information from composer.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PACKAGE = easyrdf
-VERSION = $(shell php -r "print json_decode(file_get_contents('composer.json'))->version;")
-distdir = $(PACKAGE)-$(VERSION)
+distdir = $(PACKAGE)
 PHP = $(shell which php)
 COMPOSER_FLAGS=--no-ansi --no-interaction
 PHPUNIT = vendor/bin/phpunit 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "easyrdf/easyrdf",
-    "version": "1.0.0-alpha.1",
     "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
     "type": "library",
     "keywords": ["RDF", "Semantic Web", "Linked Data", "Turtle", "RDFa", "SPARQL"],


### PR DESCRIPTION
Its not neccessary and may lead to problems with Packagist.

**Quotes** from https://getcomposer.org/doc/04-schema.md#version:

> In most cases this is not required and should be omitted (see below).

and 

> Packagist uses VCS repositories, so the statement above is very much true for Packagist as well. Specifying the version yourself will most likely end up creating problems at some point due to human error.