### PR TITLE
Removed version number from composer.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE = easyrdf
-VERSION = $(shell php -r "print json_decode(file_get_contents('composer.json'))->version;")
+VERSION = $(shell php -r "print json_decode(file_get_contents('composer.json'))->version ?? 'dev';")
 distdir = $(PACKAGE)-$(VERSION)
 PHP = $(shell which php)
 COMPOSER_FLAGS=--no-ansi --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "easyrdf/easyrdf",
-    "version": "1.0.0",
     "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
     "type": "library",
     "keywords": ["RDF", "Semantic Web", "Linked Data", "Turtle", "RDFa", "SPARQL"],


### PR DESCRIPTION
This reportedly causes problems when forking
And packagist gets unhappy if the version number in composer.json doesn't match the tag name