### PR TITLE
Fix #271: undefined index path in Http\Client::request

### DIFF
--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -442,8 +442,16 @@ class Client
             stream_set_timeout($socket, $this->config['timeout']);
             $info = stream_get_meta_data($socket);
 
-            // Write the request
-            $path = $uri['path'];
+            /*
+             * Write the request
+             *
+             * Because parse_url only sets up keys for parts present in the URI,
+             * key 'path' might be unset. The following structure uses an empty
+             * string instead in that case.
+             *
+             * FYI: https://github.com/easyrdf/easyrdf/issues/271#issuecomment-713372010
+             */
+            $path = $uri['path'] ?? '';
             if (empty($path)) {
                 $path = '/';
             }

--- a/test/EasyRdf/Http/ClientTest.php
+++ b/test/EasyRdf/Http/ClientTest.php
@@ -277,4 +277,22 @@ class ClientTest extends TestCase
         $this->assertSame(null, $this->client->getHeader('Content-Type'));
         $this->assertSame(null, $this->client->getHeader('Accept-Language'));
     }
+
+    /**
+     * Test for issue #271
+     *
+     * Test approach was to first trigger the error with the following code and
+     * deploy the fix afterwards.
+     *
+     * Error:
+     *    Undefined index: path in vendor\easyrdf\easyrdf\lib\Http\Client.php
+     *
+     * @see https://github.com/easyrdf/easyrdf/issues/271
+     */
+    public function testIssue271()
+    {
+        $this->client = new Client('https://query.wikidata.org?query=');
+        $response = $this->client->request('GET');
+        $this->assertTrue($response->isSuccessful());
+    }
 }


### PR DESCRIPTION
Fixes #271

**Problem was:** When running `Http\Client::request` it may trigger the following notice sometimes:

> Notice: Undefined index: path in vendor\easyrdf\easyrdf\lib\Http\Client.php at line 446 

Thank you @zozlak for the [info](https://github.com/easyrdf/easyrdf/issues/271#issuecomment-713372010) how to fix it.

CC @NadaBen