### PR TITLE
Add an option to get the 'expand' version for jsonLD

### DIFF
--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -132,9 +132,9 @@ class JsonLd extends Serialiser
         if ($should_frame) {
             $data = LD\JsonLD::frame($data, $options['frame'], $options);
         } elseif ($should_expand) {
-           $data = LD\JsonLD::expand($data);
+            $data = LD\JsonLD::expand($data);
         }
-        
+
         if ($should_compact) {
             // compact form
             $compact_context = isset($options['context']) ? $options['context'] : null;

--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -123,11 +123,15 @@ class JsonLd extends Serialiser
         // OPTIONS
         $use_native_types = !(isset($options['expand_native_types']) and $options['expand_native_types'] == true);
         $should_compact = (isset($options['compact']) and $options['compact'] == true);
+        $should_expand = (isset($options['expand']) and $options['expand'] == true);
         $should_frame = isset($options['frame']);
 
         // expanded form
         $data = $ld_graph->toJsonLd($use_native_types);
 
+        if ($should_expand) {
+            $data = LD\JsonLD::expand($data);
+        }
         if ($should_frame) {
             $data = LD\JsonLD::frame($data, $options['frame'], $options);
         }

--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -129,13 +129,12 @@ class JsonLd extends Serialiser
         // expanded form
         $data = $ld_graph->toJsonLd($use_native_types);
 
-        if ($should_expand) {
-            $data = LD\JsonLD::expand($data);
-        }
         if ($should_frame) {
             $data = LD\JsonLD::frame($data, $options['frame'], $options);
+        } elseif ($should_expand) {
+           $data = LD\JsonLD::expand($data);
         }
-
+        
         if ($should_compact) {
             // compact form
             $compact_context = isset($options['context']) ? $options['context'] : null;

--- a/test/EasyRdf/Serialiser/JsonLdTest.php
+++ b/test/EasyRdf/Serialiser/JsonLdTest.php
@@ -233,11 +233,11 @@ class JsonLdTest extends TestCase
         $string = $this->serialiser->serialise(
             $this->graph,
             'jsonld',
-	    array('expand' => true)
+            array('expand' => true)
         );
         $decoded = json_decode($string, true);
-	$this->assertArrayNotHasKey('@graph', $decoded);
-	$this->assertSame(
+        $this->assertArrayNotHasKey('@graph', $decoded);
+        $this->assertSame(
             'http://example.org/library',
             $decoded[1]['@id']
         );
@@ -249,8 +249,9 @@ class JsonLdTest extends TestCase
             'http://example.org/library/the-republic#introduction',
             $decoded[3]['@id']
         );
-	$this->assertSame('http://www.example.com/joe#me',
-	    $decoded[4]['@id']
-	);
+        $this->assertSame(
+            'http://www.example.com/joe#me',
+            $decoded[4]['@id']
+        );
     }
 }

--- a/test/EasyRdf/Serialiser/JsonLdTest.php
+++ b/test/EasyRdf/Serialiser/JsonLdTest.php
@@ -228,5 +228,29 @@ class JsonLdTest extends TestCase
             'http://example.org/library/the-republic#introduction',
             $decoded['@graph'][0]['ex:contains']['ex:contains']['@id']
         );
+
+        // Expanded
+        $string = $this->serialiser->serialise(
+            $this->graph,
+            'jsonld',
+	    array('expand' => true)
+        );
+        $decoded = json_decode($string, true);
+	$this->assertArrayNotHasKey('@graph', $decoded);
+	$this->assertSame(
+            'http://example.org/library',
+            $decoded[1]['@id']
+        );
+        $this->assertSame(
+            'http://example.org/library/the-republic',
+            $decoded[2]['@id']
+        );
+        $this->assertSame(
+            'http://example.org/library/the-republic#introduction',
+            $decoded[3]['@id']
+        );
+	$this->assertSame('http://www.example.com/joe#me',
+	    $decoded[4]['@id']
+	);
     }
 }


### PR DESCRIPTION
Simple addition to the jsonLD serializer to add an option for the 'expand' version.