### PR TITLE
Steps towards PHP 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       dist: trusty
     - php: 7.4
       dist: trusty
-    - php: 8.0
+    - php: nightly
 
 sudo: required
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       dist: trusty
     - php: 7.4
       dist: trusty
-    - php: nightly
+    - php: 8.0
 
 sudo: required
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
       dist: trusty
     - php: 7.4
       dist: trusty
+    - php: 8.0
 
 sudo: required
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,28 @@
 EasyRdf 1.1.0
 =============
 
-Enhancements
-------------------
-* Replace abandonned Sami by Doctum
+Bug fix release with a few improvements and changes in Composer dependencies.
+
+Overview
+--------
+
+* Composer:
+  * changed ARC2 from `~2.2` to `^2.4` (#347)
+  * replaced `sami/sami` with `code-lts/doctum`
+  * added the following required PHP extensions: ext-pcre, ext-xmlreader, lib-libxml
+* Accept an array of properties in get/getLiteral/getResource methods, fixes #325 (#326)
+* Add support for parsing large SPARQL XML Results (#357)
+* Made `Parser` class abstract, to be in line with `Serialiser` class (#328)
+* Fixed "Sparql\Client uses invalid parameters for Zend\Http\Client->setHeaders" (#335)
+* Fixed undefined index path in Http\Client::request (#271, #368)
+
+Highlights for EasyRdf developers
+---------------------------------
+
+* added .editorconfig (#340)
+* added a basic Docker setup to improve local development and testing (#334)
+* added `CONTRIBUTING.md`
+
 
 EasyRdf 1.0.0
 =============

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "ml/json-ld": "~1.0",
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^7 || ^8 || ^9",
         "code-lts/doctum": "^5",
         "semsol/arc2": "^2.4",
         "squizlabs/php_codesniffer": "3.*",

--- a/config/phpunit.xml
+++ b/config/phpunit.xml
@@ -1,27 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" verbose="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage includeUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../lib/EasyRdf/</directory>
-    </include>
-  </coverage>
-  <php>
-    <!--
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    verbose="false">
+
+    <php>
+      <!--
         Fix for coverage report causing Seg Fault
         (see https://bugs.php.net/bug.php?id=53976)
       -->
-    <ini name="zend.enable_gc" value="0"/>
-  </php>
-  <testsuites>
-    <testsuite name="EasyRdf Library">
-      <directory suffix="Test.php">../test/EasyRdf/</directory>
-    </testsuite>
-    <testsuite name="EasyRdf Examples">
-      <directory suffix="Test.php">../test/examples/</directory>
-    </testsuite>
-  </testsuites>
-  <!-- Files to be included in the coverage report -->
-  <logging>
-    <junit outputFile="../reports/test-results.xml"/>
-  </logging>
+      <ini name="zend.enable_gc" value="0" />
+    </php>
+
+    <testsuites>
+      <testsuite name="EasyRdf Library">
+        <directory suffix="Test.php">../test/EasyRdf/</directory>
+      </testsuite>
+      <testsuite name="EasyRdf Examples">
+        <directory suffix="Test.php">../test/examples/</directory>
+      </testsuite>
+    </testsuites>
+
+    <!-- Files to be included in the coverage report -->
+    <filter>
+      <whitelist addUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">../lib/EasyRdf/</directory>
+      </whitelist>
+    </filter>
+
+    <logging>
+        <log type="junit" target="../reports/test-results.xml" />
+    </logging>
 </phpunit>

--- a/config/phpunit.xml
+++ b/config/phpunit.xml
@@ -1,40 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    colors="false"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    verbose="false">
-
-    <php>
-      <!--
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" verbose="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">../lib/EasyRdf/</directory>
+    </include>
+  </coverage>
+  <php>
+    <!--
         Fix for coverage report causing Seg Fault
         (see https://bugs.php.net/bug.php?id=53976)
       -->
-      <ini name="zend.enable_gc" value="0" />
-    </php>
-
-    <testsuites>
-      <testsuite name="EasyRdf Library">
-        <directory suffix="Test.php">../test/EasyRdf/</directory>
-      </testsuite>
-      <testsuite name="EasyRdf Examples">
-        <directory suffix="Test.php">../test/examples/</directory>
-      </testsuite>
-    </testsuites>
-
-    <!-- Files to be included in the coverage report -->
-    <filter>
-      <whitelist addUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">../lib/EasyRdf/</directory>
-      </whitelist>
-    </filter>
-
-    <logging>
-        <log type="junit" target="../reports/test-results.xml" />
-    </logging>
+    <ini name="zend.enable_gc" value="0"/>
+  </php>
+  <testsuites>
+    <testsuite name="EasyRdf Library">
+      <directory suffix="Test.php">../test/EasyRdf/</directory>
+    </testsuite>
+    <testsuite name="EasyRdf Examples">
+      <directory suffix="Test.php">../test/examples/</directory>
+    </testsuite>
+  </testsuites>
+  <!-- Files to be included in the coverage report -->
+  <logging>
+    <junit outputFile="../reports/test-results.xml"/>
+  </logging>
 </phpunit>

--- a/examples/converter.php
+++ b/examples/converter.php
@@ -31,8 +31,7 @@
         }
     }
 
-    // Stupid PHP :(
-    if (get_magic_quotes_gpc() and isset($_REQUEST['data'])) {
+    if (isset($_REQUEST['data'])) {
         $_REQUEST['data'] = stripslashes($_REQUEST['data']);
     }
 

--- a/examples/sparql_queryform.php
+++ b/examples/sparql_queryform.php
@@ -20,8 +20,7 @@
     require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
     require_once __DIR__."/html_tag_helpers.php";
 
-    // Stupid PHP :(
-    if (get_magic_quotes_gpc() and isset($_REQUEST['query'])) {
+    if (isset($_REQUEST['query'])) {
         $_REQUEST['query'] = stripslashes($_REQUEST['query']);
     }
 ?>

--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -373,7 +373,7 @@ class Graph
     /** Get an associative array of all the resources stored in the graph.
      *  The keys of the array is the URI of the EasyRdf\Resource.
      *
-     * @return Resource[]
+     * @return \EasyRdf\Resource[]
      */
     public function resources()
     {
@@ -407,7 +407,7 @@ class Graph
      * @param  string  $property   The property to check.
      * @param  mixed   $value      Optional, the value of the propery to check for.
      *
-     * @return Resource[]
+     * @return \EasyRdf\Resource[]
      */
     public function resourcesMatching($property, $value = null)
     {
@@ -703,7 +703,7 @@ class Graph
      * @param  string|array $property The name of the property (e.g. foaf:name)
      * @param  string       $lang     The language to filter by (e.g. en)
      *
-     * @return Literal  Literal value associated with the property
+     * @return \EasyRdf\Literal Literal value associated with the property
      */
     public function getLiteral($resource, $property, $lang = null)
     {
@@ -1527,7 +1527,7 @@ class Graph
      *
      * @param string|null $resource
      *
-     * @return Resource[]
+     * @return \EasyRdf\Resource[]
      */
     public function typesAsResources($resource = null)
     {
@@ -1612,7 +1612,7 @@ class Graph
      * @param string|null $resource
      * @param string|null $lang
      *
-     * @return string A label for the resource.
+     * @return \EasyRdf\Literal|null An instance of Literal which contains the label or null.
      */
     public function label($resource = null, $lang = null)
     {

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -388,7 +388,7 @@ class Resource implements \ArrayAccess
      * @param  string|array $property The name of the property (e.g. foaf:name)
      * @param  string       $lang     The language to filter by (e.g. en)
      *
-     * @return Literal  Literal value associated with the property
+     * @return \EasyRdf\Literal  Literal value associated with the property
      */
     public function getLiteral($property, $lang = null)
     {
@@ -659,7 +659,7 @@ class Resource implements \ArrayAccess
      *
      * @param string|null $lang
      *
-     * @return string A label for the resource.
+     * @return \EasyRdf\Literal|null An instance of Literal which contains the label or null.
      */
     public function label($lang = null)
     {

--- a/test/EasyRdf/CollectionTest.php
+++ b/test/EasyRdf/CollectionTest.php
@@ -40,13 +40,13 @@ require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class CollectionTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         RdfNamespace::set('ex', 'http://example.org/');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::delete('ex');
     }

--- a/test/EasyRdf/ContainerTest.php
+++ b/test/EasyRdf/ContainerTest.php
@@ -40,13 +40,13 @@ require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ContainerTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         RdfNamespace::set('ex', 'http://example.org/');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::delete('ex');
     }

--- a/test/EasyRdf/FormatTest.php
+++ b/test/EasyRdf/FormatTest.php
@@ -54,7 +54,7 @@ class FormatTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->format = Format::register(
             'my',
@@ -65,7 +65,7 @@ class FormatTest extends TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Format::unregister('my');
     }
@@ -100,7 +100,7 @@ class FormatTest extends TestCase
     public function testGetFormats()
     {
         $formats = Format::getFormats();
-        $this->assertInternalType('array', $formats);
+        $this->assertEquals('array', gettype($formats));
         $this->assertGreaterThan(0, count($formats));
         foreach ($formats as $format) {
             $this->assertClass('EasyRdf\Format', $format);
@@ -110,15 +110,15 @@ class FormatTest extends TestCase
     public function testGetHttpAcceptHeader()
     {
         $accept = Format::getHttpAcceptHeader();
-        $this->assertContains('application/json', $accept);
-        $this->assertContains('application/rdf+xml;q=0.8', $accept);
+        $this->assertStringContainsString('application/json', $accept);
+        $this->assertStringContainsString('application/rdf+xml;q=0.8', $accept);
     }
 
     public function testGetHttpAcceptHeaderWithExtra()
     {
         $accept = Format::getHttpAcceptHeader(array('extra/header' => 0.5));
-        $this->assertContains('application/json', $accept);
-        $this->assertContains('extra/header;q=0.5', $accept);
+        $this->assertStringContainsString('application/json', $accept);
+        $this->assertStringContainsString('extra/header;q=0.5', $accept);
     }
 
     public function testGetHttpAcceptHeaderLocale()
@@ -127,7 +127,7 @@ class FormatTest extends TestCase
         setlocale(LC_NUMERIC, 'fi_FI.UTF-8');
 
         $accept = Format::getHttpAcceptHeader(array('extra/header' => 0.5));
-        $this->assertContains('extra/header;q=0.5', $accept);
+        $this->assertStringContainsString('extra/header;q=0.5', $accept);
 
         setlocale(LC_NUMERIC, $current_locale);
     }
@@ -469,7 +469,7 @@ class FormatTest extends TestCase
     {
         $this->format->setParserClass('EasyRdf\MockParserClass');
         $parser = $this->format->newParser();
-        $this->assertInternalType('object', $parser);
+        $this->assertEquals('object', gettype($parser));
         $this->assertClass('EasyRdf\MockParserClass', $parser);
     }
 
@@ -517,7 +517,7 @@ class FormatTest extends TestCase
     {
         $this->format->setSerialiserClass('EasyRdf\MockSerialiserClass');
         $serialiser = $this->format->newSerialiser();
-        $this->assertInternalType('object', $serialiser);
+        $this->assertEquals('object', gettype($serialiser));
         $this->assertClass('EasyRdf\MockSerialiserClass', $serialiser);
     }
 

--- a/test/EasyRdf/GraphStoreTest.php
+++ b/test/EasyRdf/GraphStoreTest.php
@@ -48,7 +48,7 @@ class GraphStoreTest extends TestCase
     /** @var MockClient */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         Http::setDefaultHttpClient(
             $this->client = new MockClient()

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -72,7 +72,7 @@ class GraphTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         // Reset to built-in parsers
         Format::registerParser('ntriples', 'EasyRdf\Parser\Ntriples');
@@ -167,7 +167,7 @@ class GraphTest extends TestCase
 
         $doc = $graph->get('foaf:PersonalProfileDocument', '^rdf:type');
         $this->assertClass('EasyRdf\Resource', $doc);
-        $this->assertRegExp('|^file://.+/fixtures/foaf\.rdf$|', $doc->getUri());
+        $this->assertMatchesRegularExpression('|^file://.+/fixtures/foaf\.rdf$|', $doc->getUri());
     }
 
     public function testParseUnknownFormat()
@@ -275,7 +275,7 @@ class GraphTest extends TestCase
     public function testLoadWithContentType()
     {
         $checkRequest = function ($client) {
-            $this->assertContains(",application/json,", $client->getHeader('Accept'));
+            $this->assertStringContainsString(",application/json,", $client->getHeader('Accept'));
             return true;
         };
         $this->client->addMockOnce(
@@ -1853,26 +1853,26 @@ class GraphTest extends TestCase
     public function testDumpText()
     {
         $text = $this->graph->dump('text');
-        $this->assertContains('Graph: http://example.com/graph', $text);
-        $this->assertContains('http://example.com/#me (EasyRdf\Resource)', $text);
-        $this->assertContains('  -> rdf:type -> foaf:Person', $text);
-        $this->assertContains('  -> rdf:test -> "Test A"', $text);
+        $this->assertStringContainsString('Graph: http://example.com/graph', $text);
+        $this->assertStringContainsString('http://example.com/#me (EasyRdf\Resource)', $text);
+        $this->assertStringContainsString('  -> rdf:type -> foaf:Person', $text);
+        $this->assertStringContainsString('  -> rdf:test -> "Test A"', $text);
     }
 
     public function testDumpEmptyGraph()
     {
         $graph = new Graph('http://example.com/graph2');
         $this->assertSame("Graph: http://example.com/graph2\n", $graph->dump('text'));
-        $this->assertContains('>Graph: http://example.com/graph2</div>', $graph->dump('html'));
+        $this->assertStringContainsString('>Graph: http://example.com/graph2</div>', $graph->dump('html'));
     }
 
     public function testDumpHtml()
     {
         $html = $this->graph->dump('html');
-        $this->assertContains('Graph: http://example.com/graph', $html);
-        $this->assertContains('http://example.com/#me', $html);
-        $this->assertContains('>rdf:test</span>', $html);
-        $this->assertContains('>&quot;Test A&quot;</span>', $html);
+        $this->assertStringContainsString('Graph: http://example.com/graph', $html);
+        $this->assertStringContainsString('http://example.com/#me', $html);
+        $this->assertStringContainsString('>rdf:test</span>', $html);
+        $this->assertStringContainsString('>&quot;Test A&quot;</span>', $html);
     }
 
     public function testDumpLiterals()
@@ -1885,22 +1885,22 @@ class GraphTest extends TestCase
         $graph->add('http://example.com/joe#me', '<http://v.example.com/foo>', 'bar');
 
         $text = $graph->dump('text');
-        $this->assertContains('http://example.com/joe#me', $text);
-        $this->assertContains('-> foaf:name -> "Joe"', $text);
-        $this->assertContains('-> foaf:age -> "52"^^xsd:integer', $text);
-        $this->assertContains('-> foaf:birthPlace -> "Deutschland"@de', $text);
-        $this->assertContains('-> <http://v.example.com/foo> -> "bar"', $text);
+        $this->assertStringContainsString('http://example.com/joe#me', $text);
+        $this->assertStringContainsString('-> foaf:name -> "Joe"', $text);
+        $this->assertStringContainsString('-> foaf:age -> "52"^^xsd:integer', $text);
+        $this->assertStringContainsString('-> foaf:birthPlace -> "Deutschland"@de', $text);
+        $this->assertStringContainsString('-> <http://v.example.com/foo> -> "bar"', $text);
 
         $html = $graph->dump('html');
-        $this->assertContains('http://example.com/joe#me', $html);
-        $this->assertContains('>foaf:name</span>', $html);
-        $this->assertContains('>&quot;Joe&quot;</span>', $html);
-        $this->assertContains('>foaf:age</span>', $html);
-        $this->assertContains('>&quot;52&quot;^^xsd:integer</span>', $html);
-        $this->assertContains('>foaf:birthPlace</span>', $html);
-        $this->assertContains('>&quot;Deutschland&quot;@de</span>', $html);
-        $this->assertContains('>&lt;http://v.example.com/foo&gt;</span>', $html);
-        $this->assertContains('>&quot;bar&quot;</span>', $html);
+        $this->assertStringContainsString('http://example.com/joe#me', $html);
+        $this->assertStringContainsString('>foaf:name</span>', $html);
+        $this->assertStringContainsString('>&quot;Joe&quot;</span>', $html);
+        $this->assertStringContainsString('>foaf:age</span>', $html);
+        $this->assertStringContainsString('>&quot;52&quot;^^xsd:integer</span>', $html);
+        $this->assertStringContainsString('>foaf:birthPlace</span>', $html);
+        $this->assertStringContainsString('>&quot;Deutschland&quot;@de</span>', $html);
+        $this->assertStringContainsString('>&lt;http://v.example.com/foo&gt;</span>', $html);
+        $this->assertStringContainsString('>&quot;bar&quot;</span>', $html);
     }
 
     public function testDumpResource()
@@ -1911,19 +1911,19 @@ class GraphTest extends TestCase
         $graph->add('http://example.com/joe#me', 'foaf:knows', $graph->newBnode());
 
         $text = $graph->dumpResource('http://example.com/joe#me', 'text');
-        $this->assertContains('http://example.com/joe#me', $text);
-        $this->assertContains('-> rdf:type -> foaf:Person', $text);
-        $this->assertContains('-> foaf:homepage -> http://example.com/', $text);
-        $this->assertContains('-> foaf:knows -> _:genid1', $text);
+        $this->assertStringContainsString('http://example.com/joe#me', $text);
+        $this->assertStringContainsString('-> rdf:type -> foaf:Person', $text);
+        $this->assertStringContainsString('-> foaf:homepage -> http://example.com/', $text);
+        $this->assertStringContainsString('-> foaf:knows -> _:genid1', $text);
 
         $html = $graph->dumpResource('http://example.com/joe#me', 'html');
-        $this->assertContains('http://example.com/joe#me', $html);
-        $this->assertContains('>rdf:type</span>', $html);
-        $this->assertContains('>foaf:Person</a>', $html);
-        $this->assertContains('>foaf:homepage</span>', $html);
-        $this->assertContains('>http://example.com/</a>', $html);
-        $this->assertContains('>foaf:knows</span>', $html);
-        $this->assertContains('>_:genid1</a>', $html);
+        $this->assertStringContainsString('http://example.com/joe#me', $html);
+        $this->assertStringContainsString('>rdf:type</span>', $html);
+        $this->assertStringContainsString('>foaf:Person</a>', $html);
+        $this->assertStringContainsString('>foaf:homepage</span>', $html);
+        $this->assertStringContainsString('>http://example.com/</a>', $html);
+        $this->assertStringContainsString('>foaf:knows</span>', $html);
+        $this->assertStringContainsString('>_:genid1</a>', $html);
     }
 
     public function testDumpResourceWithNoProperties()
@@ -1937,7 +1937,7 @@ class GraphTest extends TestCase
     {
         $graph = new Graph();
         $graph->addType("wikibase_id:Q' onload='alert(1234)", 'foaf:Person');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<div id='wikibase_id:Q&#039; onload=&#039;alert(1234)' ".
             "style='font-family:arial; padding:0.5em; background-color:lightgrey;border:dashed 1px grey;'>",
             $graph->dumpResource("wikibase_id:Q' onload='alert(1234)")

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -167,7 +167,7 @@ class GraphTest extends TestCase
 
         $doc = $graph->get('foaf:PersonalProfileDocument', '^rdf:type');
         $this->assertClass('EasyRdf\Resource', $doc);
-        $this->assertMatchesRegularExpression('|^file://.+/fixtures/foaf\.rdf$|', $doc->getUri());
+        self::assertMatchesRegularExpression('|^file://.+/fixtures/foaf\.rdf$|', $doc->getUri());
     }
 
     public function testParseUnknownFormat()

--- a/test/EasyRdf/Http/ClientTest.php
+++ b/test/EasyRdf/Http/ClientTest.php
@@ -55,7 +55,7 @@ class ClientTest extends TestCase
      * Set up the test suite before each test
      *
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new Client('http://www.example.com/');
     }

--- a/test/EasyRdf/Http/MockClientTest.php
+++ b/test/EasyRdf/Http/MockClientTest.php
@@ -47,7 +47,7 @@ class MockClientTest extends TestCase
     /** @var MockClient */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new MockClient();
     }

--- a/test/EasyRdf/IsomorphicTest.php
+++ b/test/EasyRdf/IsomorphicTest.php
@@ -48,7 +48,7 @@ class IsomorphicTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->graphA = new Graph();
         $this->graphB = new Graph();

--- a/test/EasyRdf/Literal/BooleanTest.php
+++ b/test/EasyRdf/Literal/BooleanTest.php
@@ -47,7 +47,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('true');
         $this->assertStringEquals('true', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -57,7 +57,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('false');
         $this->assertStringEquals('false', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -67,7 +67,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('1');
         $this->assertStringEquals('1', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -77,7 +77,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('0');
         $this->assertStringEquals('0', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -87,7 +87,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(true);
         $this->assertStringEquals('true', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -97,7 +97,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(false);
         $this->assertStringEquals('false', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -107,7 +107,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(1);
         $this->assertStringEquals('true', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -117,7 +117,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(0);
         $this->assertStringEquals('false', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());

--- a/test/EasyRdf/Literal/DateTest.php
+++ b/test/EasyRdf/Literal/DateTest.php
@@ -70,7 +70,7 @@ class DateTest extends TestCase
         $today = new \DateTime('today');
         $literal = new Date();
         $this->assertEquals($today, $literal->getValue());
-        $this->assertRegExp('|^\d{4}-\d{2}-\d{2}$|', strval($literal));
+        $this->assertMatchesRegularExpression('|^\d{4}-\d{2}-\d{2}$|', strval($literal));
     }
 
     public function testParse()

--- a/test/EasyRdf/Literal/DateTest.php
+++ b/test/EasyRdf/Literal/DateTest.php
@@ -70,7 +70,7 @@ class DateTest extends TestCase
         $today = new \DateTime('today');
         $literal = new Date();
         $this->assertEquals($today, $literal->getValue());
-        $this->assertMatchesRegularExpression('|^\d{4}-\d{2}-\d{2}$|', strval($literal));
+        self::assertMatchesRegularExpression('|^\d{4}-\d{2}-\d{2}$|', strval($literal));
     }
 
     public function testParse()

--- a/test/EasyRdf/Literal/DateTimeTest.php
+++ b/test/EasyRdf/Literal/DateTimeTest.php
@@ -105,7 +105,7 @@ class DateTimeTest extends TestCase
 
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->dt = new DateTime('2010-09-08T07:06:05Z');
     }

--- a/test/EasyRdf/Literal/DecimalTest.php
+++ b/test/EasyRdf/Literal/DecimalTest.php
@@ -46,7 +46,7 @@ class DecimalTest extends TestCase
     public function testConstruct15()
     {
         $literal = new Decimal(1.5);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertEquals('string', gettype($literal->getValue()));
         $this->assertSame('1.5', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
@@ -60,7 +60,7 @@ class DecimalTest extends TestCase
 
         try {
             $literal = new Decimal(1.5);
-            $this->assertInternalType('string', $literal->getValue());
+            $this->assertEquals('string', gettype($literal->getValue()));
             $this->assertSame('1.5', $literal->getValue());
             $this->assertSame(null, $literal->getLang());
             $this->assertSame('xsd:decimal', $literal->getDatatype());
@@ -75,7 +75,7 @@ class DecimalTest extends TestCase
     public function testConstructString100()
     {
         $literal = new Decimal('100.00');
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertEquals('string', gettype($literal->getValue()));
         $this->assertSame('100.0', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:decimal', $literal->getDatatype());

--- a/test/EasyRdf/Literal/HTMLTest.php
+++ b/test/EasyRdf/Literal/HTMLTest.php
@@ -48,7 +48,7 @@ class HTMLTest extends TestCase
         $literal = new HTML('<p>Hello World</p>');
         $this->assertClass('EasyRdf\Literal\HTML', $literal);
         $this->assertStringEquals('<p>Hello World</p>', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertEquals('string', gettype($literal->getValue()));
         $this->assertSame('<p>Hello World</p>', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('rdf:HTML', $literal->getDatatype());

--- a/test/EasyRdf/Literal/HexBinaryTest.php
+++ b/test/EasyRdf/Literal/HexBinaryTest.php
@@ -45,7 +45,7 @@ require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
 
 class HexBinaryTest extends TestCase
 {
-    public function setup()
+    public function setUp(): void
     {
         // Reset to built-in parsers
         Format::registerParser('ntriples', 'EasyRdf\Parser\Ntriples');
@@ -57,7 +57,7 @@ class HexBinaryTest extends TestCase
     {
         $literal = new HexBinary('48656C6C6F');
         $this->assertStringEquals('48656C6C6F', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertEquals('string', gettype($literal->getValue()));
         $this->assertSame('48656C6C6F', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:hexBinary', $literal->getDatatype());
@@ -132,7 +132,7 @@ class HexBinaryTest extends TestCase
             '71FD4F207AD770809E0E2D7B0EF5493BEFE73544D8E1BE3DDDB52455C61391A1',
             $modulus
         );
-        $this->assertInternalType('string', $modulus->getValue());
+        $this->assertEquals('string', gettype($modulus->getValue()));
         $this->assertSame(null, $modulus->getLang());
         $this->assertSame('xsd:hexBinary', $modulus->getDatatype());
     }

--- a/test/EasyRdf/Literal/IntegerTest.php
+++ b/test/EasyRdf/Literal/IntegerTest.php
@@ -48,7 +48,7 @@ class IntegerTest extends TestCase
         $literal = new Integer(0);
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('0', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertEquals('integer', gettype($literal->getValue()));
         $this->assertSame(0, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
@@ -59,7 +59,7 @@ class IntegerTest extends TestCase
         $literal = new Integer(1);
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('1', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertEquals('integer', gettype($literal->getValue()));
         $this->assertSame(1, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
@@ -70,7 +70,7 @@ class IntegerTest extends TestCase
         $literal = new Integer('100');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('100', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertEquals('integer', gettype($literal->getValue()));
         $this->assertSame(100, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
@@ -81,7 +81,7 @@ class IntegerTest extends TestCase
         $literal = new Integer('0100');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('0100', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertEquals('integer', gettype($literal->getValue()));
         $this->assertSame(100, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());

--- a/test/EasyRdf/Literal/XMLTest.php
+++ b/test/EasyRdf/Literal/XMLTest.php
@@ -48,7 +48,7 @@ class XMLTest extends TestCase
         $literal = new XML('<tag>Hello World</tag>');
         $this->assertClass('EasyRdf\Literal\XML', $literal);
         $this->assertStringEquals('<tag>Hello World</tag>', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertEquals('string', gettype($literal->getValue()));
         $this->assertSame('<tag>Hello World</tag>', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('rdf:XMLLiteral', $literal->getDatatype());

--- a/test/EasyRdf/LiteralTest.php
+++ b/test/EasyRdf/LiteralTest.php
@@ -48,12 +48,12 @@ class MyDatatypeClass extends Literal
 
 class LiteralTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         RdfNamespace::set('ex', 'http://www.example.com/');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Literal::deleteDatatypeMapping('ex:mytype');
         RdfNamespace::delete('ex');
@@ -242,7 +242,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(1, null, 'xsd:boolean');
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(true, $literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -252,7 +252,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(0, null, 'xsd:boolean');
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertEquals('boolean', gettype($literal->getValue()));
         $this->assertSame(false, $literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -262,7 +262,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create('100.00', null, 'xsd:integer');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
-        $this->assertInternalType('integer', $literal->getValue());
+        $this->assertEquals('integer', gettype($literal->getValue()));
         $this->assertSame(100, $literal->getValue());
         $this->assertSame('xsd:integer', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -272,7 +272,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create('1', null, 'xsd:decimal');
         $this->assertClass('EasyRdf\Literal\Decimal', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertEquals('string', gettype($literal->getValue()));
         $this->assertSame('1.0', $literal->getValue());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -282,8 +282,8 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(true, null, 'xsd:string');
         $this->assertClass('EasyRdf\Literal', $literal);
-        $this->assertInternalType('string', $literal->getValue());
-        # Hmm, not sure about this, but PHP does the conversion not me:
+        $this->assertEquals('string', gettype($literal->getValue()));
+        // Hmm, not sure about this, but PHP does the conversion not me
         $this->assertSame('1', $literal->getValue());
         $this->assertSame('xsd:string', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());

--- a/test/EasyRdf/NamespaceTest.php
+++ b/test/EasyRdf/NamespaceTest.php
@@ -45,14 +45,14 @@ class NamespaceTest extends TestCase
     /** @var Resource */
     private $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         RdfNamespace::setDefault(null);
         $this->graph = new Graph();
         $this->resource = $this->graph->resource('http://xmlns.com/foaf/0.1/name');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::delete('po');
         RdfNamespace::reset();

--- a/test/EasyRdf/ParsedUriTest.php
+++ b/test/EasyRdf/ParsedUriTest.php
@@ -43,7 +43,7 @@ class ParsedUriTest extends TestCase
     /** @var ParsedUri */
     private $baseUri;
 
-    public function setup()
+    public function setUp(): void
     {
         $this->baseUri = new ParsedUri(
             'http://a/b/c/d;p?q'

--- a/test/EasyRdf/Parser/ArcTest.php
+++ b/test/EasyRdf/Parser/ArcTest.php
@@ -50,7 +50,7 @@ class ArcTest extends TestCase
     protected $graph = null;
     protected $data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (class_exists('ARC2')) {
             $this->parser = new Arc();

--- a/test/EasyRdf/Parser/JsonLdTest.php
+++ b/test/EasyRdf/Parser/JsonLdTest.php
@@ -59,7 +59,7 @@ class JsonLdTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new JsonLd();

--- a/test/EasyRdf/Parser/JsonTest.php
+++ b/test/EasyRdf/Parser/JsonTest.php
@@ -50,7 +50,7 @@ class JsonTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new Json();

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -50,7 +50,7 @@ class NtriplesTest extends TestCase
     protected $graph = null;
     protected $nt_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new Ntriples();

--- a/test/EasyRdf/Parser/RapperTest.php
+++ b/test/EasyRdf/Parser/RapperTest.php
@@ -50,7 +50,7 @@ class RapperTest extends TestCase
     protected $graph = null;
     protected $rdf_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         exec('rapper --version 2>/dev/null', $output, $retval);
         if ($retval == 0) {

--- a/test/EasyRdf/Parser/RdfPhpTest.php
+++ b/test/EasyRdf/Parser/RdfPhpTest.php
@@ -50,7 +50,7 @@ class RdfPhpTest extends TestCase
     protected $graph = null;
     protected $rdf_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new RdfPhp();
@@ -133,46 +133,51 @@ class RdfPhpTest extends TestCase
 
     /**
      * 'foo' is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput1()
     {
+        $this->expectException(Exception::class);
+
         $this->parser->parse($this->graph, 'foo', 'php', null);
     }
 
     /**
      * list of strings is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput2()
     {
+        $this->expectException(Exception::class);
+
         $this->parser->parse($this->graph, array('foo', 'bar'), 'php', null);
     }
 
     /**
      * 1-level dictionary of strings is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput3()
     {
+        $this->expectException(Exception::class);
+
         $this->parser->parse($this->graph, array('foo' => 'bar'), 'php', null);
     }
 
     /**
      * 2-level dictionary of strings is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput4()
     {
+        $this->expectException(Exception::class);
+
         $this->parser->parse($this->graph, array('foo' => array('bar' => 'baz')), 'php', null);
     }
 
     /**
      * 2-level dictionary of incorrect arrays is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput5()
     {
+        $this->expectException(Exception::class);
+
         $this->parser->parse($this->graph, array('foo' => array('bar' => array('baz' => 'buzz'))), 'php', null);
     }
 }

--- a/test/EasyRdf/Parser/RdfXmlTest.php
+++ b/test/EasyRdf/Parser/RdfXmlTest.php
@@ -50,7 +50,7 @@ class RdfXmlTest extends TestCase
     protected $graph = null;
     protected $rdf_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new RdfXml();

--- a/test/EasyRdf/Parser/RdfaTest.php
+++ b/test/EasyRdf/Parser/RdfaTest.php
@@ -53,7 +53,7 @@ class RdfaTest extends TestCase
     protected $baseUri;
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rdfaParser = new Rdfa();
         $this->ntriplesParser = new Ntriples();

--- a/test/EasyRdf/Parser/TurtleTest.php
+++ b/test/EasyRdf/Parser/TurtleTest.php
@@ -53,7 +53,7 @@ class TurtleTest extends TestCase
 
     protected $baseUri;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->turtleParser = new Turtle();
         $this->ntriplesParser = new Ntriples();

--- a/test/EasyRdf/ParserTest.php
+++ b/test/EasyRdf/ParserTest.php
@@ -59,7 +59,7 @@ class ParserTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->resource = $this->graph->resource('http://www.example.com/');

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -51,7 +51,7 @@ class ResourceTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         // Reset default namespace
         RdfNamespace::setDefault(null);
@@ -1202,45 +1202,45 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $text = $this->resource->dump('text');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'http://example.com/#me (EasyRdf\Resource)',
             $text
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '-> rdf:type -> foaf:Person',
             $text
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '-> rdf:test -> "Test A", "Test B"@en',
             $text
         );
 
         $html = $this->resource->dump();
-        $this->assertContains("<div id='http://example.com/#me'", $html);
-        $this->assertContains(
+        $this->assertStringContainsString("<div id='http://example.com/#me'", $html);
+        $this->assertStringContainsString(
             "<a href='http://example.com/#me' ".
             "style='text-decoration:none;color:blue'>".
             "http://example.com/#me</a>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='text-decoration:none;color:green'>rdf:type</span>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<a href='http://xmlns.com/foaf/0.1/Person' ".
             "style='text-decoration:none;color:blue'>foaf:Person</a>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='text-decoration:none;color:green'>rdf:test</span>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='color:black'>&quot;Test A&quot;</span>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='color:black'>&quot;Test B&quot;@en</span>",
             $html
         );

--- a/test/EasyRdf/Serialiser/ArcTest.php
+++ b/test/EasyRdf/Serialiser/ArcTest.php
@@ -49,7 +49,7 @@ class ArcTest extends TestCase
     /** @var Arc */
     private $serialiser;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (class_exists('ARC2')) {
             $this->graph = new Graph();
@@ -72,11 +72,11 @@ class ArcTest extends TestCase
 
         $rdfxml = $this->serialiser->serialise($this->graph, 'rdfxml');
         $this->assertNotNull($rdfxml);
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<rdf:Description rdf:about="http://www.example.com/joe#me">',
             $rdfxml
         );
-        $this->assertContains(':name>Project Name<', $rdfxml);
+        $this->assertStringContainsString(':name>Project Name<', $rdfxml);
     }
 
     public function testSerialiseUnsupportedFormat()

--- a/test/EasyRdf/Serialiser/GraphVizTest.php
+++ b/test/EasyRdf/Serialiser/GraphVizTest.php
@@ -238,31 +238,31 @@ class GraphVizTest extends TestCase
         $this->serialiser->setOnlyLabelled(false);
         $svg = $this->serialiser->serialise($this->graph, 'svg');
 
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="node">\s*<title>Rhttp://www.example.com/joe#me</title>|',
             $svg
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="node">\s*<title>LJoe Bloggs</title>|',
             $svg
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="edge">\s*<title>Rhttp://www.example.com/joe#me&#45;&gt;LJoe Bloggs</title>|',
             $svg
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="node">\s*<title>B_:genid1</title>|',
             $svg
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="edge">\s*<title>Rhttp://www.example.com/joe#me&#45;&gt;B_:genid1</title>|',
             $svg
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="node">\s*<title>LProject Name</title>|',
             $svg
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '|class="edge">\s*<title>B_:genid1&#45;&gt;LProject Name</title>|',
             $svg
         );

--- a/test/EasyRdf/Serialiser/GraphVizTest.php
+++ b/test/EasyRdf/Serialiser/GraphVizTest.php
@@ -49,7 +49,7 @@ class GraphVizTest extends TestCase
     /** @var GraphViz */
     private $serialiser;
 
-    public function setUp()
+    public function setUp(): void
     {
         exec('which dot 2>&1', $output, $retval);
         if ($retval == 0) {
@@ -238,31 +238,31 @@ class GraphVizTest extends TestCase
         $this->serialiser->setOnlyLabelled(false);
         $svg = $this->serialiser->serialise($this->graph, 'svg');
 
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="node">\s*<title>Rhttp://www.example.com/joe#me</title>|',
             $svg
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="node">\s*<title>LJoe Bloggs</title>|',
             $svg
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="edge">\s*<title>Rhttp://www.example.com/joe#me&#45;&gt;LJoe Bloggs</title>|',
             $svg
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="node">\s*<title>B_:genid1</title>|',
             $svg
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="edge">\s*<title>Rhttp://www.example.com/joe#me&#45;&gt;B_:genid1</title>|',
             $svg
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="node">\s*<title>LProject Name</title>|',
             $svg
         );
-        $this->assertRegExp(
+        $this->assertMatchesRegularExpression(
             '|class="edge">\s*<title>B_:genid1&#45;&gt;LProject Name</title>|',
             $svg
         );

--- a/test/EasyRdf/Serialiser/JsonLdTest.php
+++ b/test/EasyRdf/Serialiser/JsonLdTest.php
@@ -52,7 +52,7 @@ class JsonLdTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph('http://example.com/');
         $this->serialiser = new JsonLd();
@@ -86,7 +86,7 @@ class JsonLdTest extends TestCase
         $library->addResource('ex:contains', $book);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         RdfNamespace::resetNamespaces();
@@ -135,7 +135,7 @@ class JsonLdTest extends TestCase
         $decoded = json_decode($string, true);
 
         $this->assertArrayNotHasKey('@graph', $decoded);
-        $this->assertInternalType('array', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
+        $this->assertEquals('array', gettype($decoded[8]["http://xmlns.com/foaf/0.1/age"][0]));
         $this->assertSame(59, $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@value']);
         $this->assertArrayNotHasKey('@type', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
 
@@ -145,7 +145,7 @@ class JsonLdTest extends TestCase
         $decoded = json_decode($string, true);
 
         $this->assertArrayNotHasKey('@graph', $decoded);
-        $this->assertInternalType('array', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
+        $this->assertEquals('array', gettype($decoded[8]["http://xmlns.com/foaf/0.1/age"][0]));
         $this->assertSame('59', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@value']);
         $this->assertSame(
             'http://www.w3.org/2001/XMLSchema#integer',

--- a/test/EasyRdf/Serialiser/JsonTest.php
+++ b/test/EasyRdf/Serialiser/JsonTest.php
@@ -51,13 +51,13 @@ class JsonTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new Json();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         RdfNamespace::resetNamespaces();

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -52,13 +52,13 @@ class NtriplesTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new Ntriples();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         RdfNamespace::resetNamespaces();

--- a/test/EasyRdf/Serialiser/RapperTest.php
+++ b/test/EasyRdf/Serialiser/RapperTest.php
@@ -49,7 +49,7 @@ class RapperTest extends TestCase
     /** @var Rapper */
     private $serialiser;
 
-    public function setUp()
+    public function setUp(): void
     {
         exec('which rapper 2>&1', $output, $retval);
         if ($retval == 0) {
@@ -82,11 +82,11 @@ class RapperTest extends TestCase
 
         $rdfxml = $this->serialiser->serialise($this->graph, 'rdfxml');
         $this->assertNotNull($rdfxml);
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<rdf:Description rdf:about="http://www.example.com/joe#me">',
             $rdfxml
         );
-        $this->assertContains(':name>Project Name<', $rdfxml);
+        $this->assertStringContainsString(':name>Project Name<', $rdfxml);
     }
 
     public function testSerialiseUnsupportedFormat()

--- a/test/EasyRdf/Serialiser/RdfPhpTest.php
+++ b/test/EasyRdf/Serialiser/RdfPhpTest.php
@@ -50,7 +50,7 @@ class RdfPhpTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new RdfPhp();
@@ -69,20 +69,20 @@ class RdfPhpTest extends TestCase
         $joe->add('foaf:project', $project);
 
         $php = $this->serialiser->serialise($this->graph, 'php');
-        $this->assertInternalType('array', $php);
+        $this->assertEquals('array', gettype($php));
         $subject = $php['http://www.example.com/joe#me'];
-        $this->assertInternalType('array', $subject);
+        $this->assertEquals('array', gettype($subject));
         $type = $subject['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'][0];
         $this->assertSame('uri', $type['type']);
         $this->assertSame('http://xmlns.com/foaf/0.1/Person', $type['value']);
         $name = $subject['http://xmlns.com/foaf/0.1/name'][0];
-        $this->assertInternalType('array', $name);
+        $this->assertEquals('array', gettype($name));
         $this->assertSame('literal', $name['type']);
         $this->assertSame('Joe Bloggs', $name['value']);
         $this->assertFalse(isset($name['datatype']));
         $this->assertSame('en', $name['lang']);
         $age = $subject['http://xmlns.com/foaf/0.1/age'][0];
-        $this->assertInternalType('array', $age);
+        $this->assertEquals('array', gettype($age));
         $this->assertSame('literal', $age['type']);
         $this->assertSame('59', $age['value']);
         $this->assertSame(
@@ -92,7 +92,7 @@ class RdfPhpTest extends TestCase
         $this->assertFalse(isset($age['lang']));
 
         $nodeid = $subject['http://xmlns.com/foaf/0.1/project'][0]['value'];
-        $this->assertInternalType('array', $php[$nodeid]);
+        $this->assertEquals('array', gettype($php[$nodeid]));
         $projectName = $php[$nodeid]['http://xmlns.com/foaf/0.1/name'][0];
         $this->assertSame('Project Name', $projectName['value']);
         $this->assertFalse(isset($projectName['lang']));

--- a/test/EasyRdf/Serialiser/RdfXmlTest.php
+++ b/test/EasyRdf/Serialiser/RdfXmlTest.php
@@ -52,19 +52,19 @@ class RdfXmlTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         RdfNamespace::resetNamespaces();
         RdfNamespace::reset();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new RdfXml();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::resetNamespaces();
         RdfNamespace::reset();
@@ -269,7 +269,7 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<foaf:name xml:lang="en">Joe</foaf:name>',
             $xml
         );
@@ -284,7 +284,7 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<foaf:age rdf:datatype=\"http://www.w3.org/2001/XMLSchema#int\">59</foaf:age>",
             $xml
         );
@@ -299,8 +299,8 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains("<ns0:foo>bar</ns0:foo>", $xml);
-        $this->assertContains("xmlns:ns0=\"http://www.example.com/ns/\"", $xml);
+        $this->assertStringContainsString("<ns0:foo>bar</ns0:foo>", $xml);
+        $this->assertStringContainsString("xmlns:ns0=\"http://www.example.com/ns/\"", $xml);
     }
 
     public function testSerialiseRdfXmlWithUnshortenableProperty()
@@ -327,7 +327,7 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<foaf:bio rdf:parseType=\"Literal\"><b>html</b></foaf:bio>",
             $xml
         );

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -51,13 +51,13 @@ class TurtleTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new Turtle();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::reset();
         RdfNamespace::resetNamespaces();
@@ -681,7 +681,7 @@ class TurtleTest extends TestCase
         $joe->set('http://example.com/ns/prop', 'bar');
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "@prefix ns0: <http://example.com/ns/> .",
             $turtle
         );

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -60,7 +60,7 @@ class SerialiserTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->resource = $this->graph->resource('http://www.example.com/');

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -53,7 +53,7 @@ class ClientTest extends TestCase
     /** @var  Client */
     private $sparql;
 
-    public function setUp()
+    public function setUp(): void
     {
         Http::setDefaultHttpClient(
             $this->client = new MockClient()
@@ -167,7 +167,7 @@ class ClientTest extends TestCase
 
     public function checkHugeQuerySelect($client)
     {
-        $this->assertRegExp('/^query=/', $client->getRawData());
+        $this->assertMatchesRegularExpression('/^query=/', $client->getRawData());
         $this->assertSame("application/x-www-form-urlencoded", $client->getHeader('Content-Type'));
         return true;
     }

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -167,7 +167,7 @@ class ClientTest extends TestCase
 
     public function checkHugeQuerySelect($client)
     {
-        $this->assertMatchesRegularExpression('/^query=/', $client->getRawData());
+        self::assertMatchesRegularExpression('/^query=/', $client->getRawData());
         $this->assertSame("application/x-www-form-urlencoded", $client->getHeader('Content-Type'));
         return true;
     }

--- a/test/EasyRdf/Sparql/ResultTest.php
+++ b/test/EasyRdf/Sparql/ResultTest.php
@@ -389,15 +389,15 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains("<table class='sparql-results'", $html);
-        $this->assertContains(">?s</th>", $html);
-        $this->assertContains(">?p</th>", $html);
-        $this->assertContains(">?o</th></tr>", $html);
+        $this->assertStringContainsString("<table class='sparql-results'", $html);
+        $this->assertStringContainsString(">?s</th>", $html);
+        $this->assertStringContainsString(">?p</th>", $html);
+        $this->assertStringContainsString(">?o</th></tr>", $html);
 
-        $this->assertContains(">http://www.example.com/joe#me</a></td>", $html);
-        $this->assertContains(">foaf:name</a></td>", $html);
-        $this->assertContains(">&quot;Joe Bloggs&quot;@en</span></td>", $html);
-        $this->assertContains("</table>", $html);
+        $this->assertStringContainsString(">http://www.example.com/joe#me</a></td>", $html);
+        $this->assertStringContainsString(">foaf:name</a></td>", $html);
+        $this->assertStringContainsString(">&quot;Joe Bloggs&quot;@en</span></td>", $html);
+        $this->assertStringContainsString("</table>", $html);
     }
 
     public function testDumpSelectAllText()
@@ -408,15 +408,15 @@ class ResultTest extends TestCase
         );
 
         $text = $result->dump('text');
-        $this->assertContains('+-------------------------------------+', $text);
-        $this->assertContains('| ?s                                  |', $text);
-        $this->assertContains('| http://www.example.com/joe#me       |', $text);
-        $this->assertContains('+---------------------+', $text);
-        $this->assertContains('| ?p                  |', $text);
-        $this->assertContains('| foaf:name           |', $text);
-        $this->assertContains('+--------------------------------+', $text);
-        $this->assertContains('| ?o                             |', $text);
-        $this->assertContains('| "Joe Bloggs"@en                |', $text);
+        $this->assertStringContainsString('+-------------------------------------+', $text);
+        $this->assertStringContainsString('| ?s                                  |', $text);
+        $this->assertStringContainsString('| http://www.example.com/joe#me       |', $text);
+        $this->assertStringContainsString('+---------------------+', $text);
+        $this->assertStringContainsString('| ?p                  |', $text);
+        $this->assertStringContainsString('| foaf:name           |', $text);
+        $this->assertStringContainsString('+--------------------------------+', $text);
+        $this->assertStringContainsString('| ?o                             |', $text);
+        $this->assertStringContainsString('| "Joe Bloggs"@en                |', $text);
     }
 
     public function testDumpSelectUnbound()
@@ -427,13 +427,13 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains(">?person</th>", $html);
-        $this->assertContains(">?name</th>", $html);
-        $this->assertContains(">?foo</th>", $html);
+        $this->assertStringContainsString(">?person</th>", $html);
+        $this->assertStringContainsString(">?name</th>", $html);
+        $this->assertStringContainsString(">?foo</th>", $html);
 
-        $this->assertContains('>http://dbpedia.org/resource/Tim_Berners-Lee</a>', $html);
-        $this->assertContains('>&quot;Tim Berners-Lee&quot;@en</span>', $html);
-        $this->assertContains('<td>&nbsp;</td>', $html);
+        $this->assertStringContainsString('>http://dbpedia.org/resource/Tim_Berners-Lee</a>', $html);
+        $this->assertStringContainsString('>&quot;Tim Berners-Lee&quot;@en</span>', $html);
+        $this->assertStringContainsString('<td>&nbsp;</td>', $html);
     }
 
     public function testDumpAskFalseHtml()
@@ -444,7 +444,7 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains(">false</span>", $html);
+        $this->assertStringContainsString(">false</span>", $html);
     }
 
     public function testDumpAskFalseText()
@@ -510,8 +510,8 @@ class ResultTest extends TestCase
         );
 
         $string = strval($result);
-        $this->assertContains('+-------------------------------------+', $string);
-        $this->assertContains('| http://www.example.com/joe#me       |', $string);
+        $this->assertStringContainsString('+-------------------------------------+', $string);
+        $this->assertStringContainsString('| http://www.example.com/joe#me       |', $string);
     }
 
     public function testUnsupportedFormat()

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -71,11 +71,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * As long as we have to support PHPUnit 7 this function is required, because its replacement in PHPUnit 9
      * is defined as a static function, but assertRegExp was non-static.
+     *
+     * @todo remove if PHPUnit 7 support is no longer required.
      */
     public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
     {
         $case = new TestCase();
-        if (!method_exists($case, 'assertMatchesRegularExpression')) {
+        if (method_exists($case, 'assertRegExp')) {
             $case->assertRegExp($pattern, $string, $message);
         } else {
             parent::assertMatchesRegularExpression($pattern, $string, $message);

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -67,4 +67,20 @@ class TestCase extends \PHPUnit\Framework\TestCase
             parent::setExpectedException($exceptionName, $exceptionMessage);
         }
     }
+
+    /**
+     * Compatibility layer for PHPUnit 7+.
+     *
+     * As long as we have to support PHPUnit 7 this function is required, because its replacement in PHPUnit 9
+     * is defined as a static function, but assertRegExp was non-static.
+     */
+    public static function assertMatchesRegularExpression(string $pattern, string $string, string $message = ''): void
+    {
+        $case = new TestCase();
+        if (!method_exists($case, 'assertMatchesRegularExpression')) {
+            $case->assertRegExp($pattern, $string, $message);
+        } else {
+            parent::assertMatchesRegularExpression($pattern, $string, $message);
+        }
+    }
 }

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -36,14 +36,8 @@ namespace EasyRdf;
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
 
-// Backward compatibility layer for PHPUnit 4
-if (!class_exists('\PHPUnit\Framework\Error\Error', true)) {
-    class_alias('PHPUnit_Framework_Error', '\PHPUnit\Framework\Error\Error');
-}
-
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-
     public static function assertStringEquals($str1, $str2, $message = null)
     {
         self::assertSame(strval($str1), strval($str2), (string) $message);
@@ -55,7 +49,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
         self::assertSame($class, get_class($object));
     }
 
-    // Forward compatibility layer for PHPUnit 6/7
+    /**
+     * Forward compatibility layer for PHPUnit 6/7
+     *
+     * @todo Outdated. Remove it and use appropriate PHPUnit functions.
+     */
     public function setExpectedException($exceptionName, $exceptionMessage = '', $exceptionCode = null)
     {
         if (method_exists($this, 'expectException')) {

--- a/test/EasyRdf/TypeMapperTest.php
+++ b/test/EasyRdf/TypeMapperTest.php
@@ -49,12 +49,12 @@ class MyTypeClass extends Resource
 
 class TypeMapperTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         TypeMapper::set('rdf:mytype', 'EasyRdf\MyTypeClass');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         TypeMapper::delete('rdf:mytype');
         TypeMapper::delete('foaf:Person');

--- a/test/FusekiTest.php
+++ b/test/FusekiTest.php
@@ -83,7 +83,7 @@ class FusekiTest extends \EasyRdf\TestCase
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->gs = new \EasyRdf\GraphStore("http://localhost:".self::$port."/ds/data");
     }

--- a/test/examples/BasicSparqlTest.php
+++ b/test/examples/BasicSparqlTest.php
@@ -43,29 +43,29 @@ class BasicSparqlTest extends \EasyRdf\TestCase
     public function testCountries()
     {
         $output = executeExample('basic_sparql.php');
-        $this->assertContains('<title>EasyRdf Basic Sparql Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf Basic Sparql Example</h1>', $output);
-        $this->assertContains('<h2>List of countries</h2>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Basic Sparql Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Basic Sparql Example</h1>', $output);
+        $this->assertStringContainsString('<h2>List of countries</h2>', $output);
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/China">China</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/India">India</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/United_States">United States</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/United_Kingdom">United Kingdom</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/Zimbabwe">Zimbabwe</a></li>',
             $output
         );
-        $this->assertRegExp('|Total number of countries: (\d+)|', $output);
+        $this->assertMatchesRegularExpression('|Total number of countries: (\d+)|', $output);
     }
 }

--- a/test/examples/BasicSparqlTest.php
+++ b/test/examples/BasicSparqlTest.php
@@ -66,6 +66,6 @@ class BasicSparqlTest extends \EasyRdf\TestCase
             '<li><a href="http://dbpedia.org/resource/Zimbabwe">Zimbabwe</a></li>',
             $output
         );
-        $this->assertMatchesRegularExpression('|Total number of countries: (\d+)|', $output);
+        self::assertMatchesRegularExpression('|Total number of countries: (\d+)|', $output);
     }
 }

--- a/test/examples/BasicTest.php
+++ b/test/examples/BasicTest.php
@@ -43,7 +43,7 @@ class BasicTest extends \EasyRdf\TestCase
     public function testPageRendersCorrectly()
     {
         $output = executeExample('basic.php');
-        $this->assertContains('<title>Basic FOAF example</title>', $output);
-        $this->assertContains('My name is: Nicholas J Humfrey', $output);
+        $this->assertStringContainsString('<title>Basic FOAF example</title>', $output);
+        $this->assertStringContainsString('My name is: Nicholas J Humfrey', $output);
     }
 }

--- a/test/examples/ConverterTest.php
+++ b/test/examples/ConverterTest.php
@@ -43,11 +43,11 @@ class ConverterTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('converter.php');
-        $this->assertContains('<title>EasyRdf Converter</title>', $output);
-        $this->assertContains('<h1>EasyRdf Converter</h1>', $output);
-        $this->assertContains('<option value="ntriples">N-Triples</option>', $output);
-        $this->assertContains('<option value="turtle">Turtle Terse RDF Triple Language</option>', $output);
-        $this->assertContains('<option value="rdfxml">RDF/XML</option>', $output);
+        $this->assertStringContainsString('<title>EasyRdf Converter</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Converter</h1>', $output);
+        $this->assertStringContainsString('<option value="ntriples">N-Triples</option>', $output);
+        $this->assertStringContainsString('<option value="turtle">Turtle Terse RDF Triple Language</option>', $output);
+        $this->assertStringContainsString('<option value="rdfxml">RDF/XML</option>', $output);
     }
 
     public function testConvertRdfXmlToNtriples()
@@ -68,9 +68,9 @@ class ConverterTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf Converter</title>', $output);
-        $this->assertContains('<h1>EasyRdf Converter</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Converter</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Converter</h1>', $output);
+        $this->assertStringContainsString(
             '&lt;http://www.w3.org/&gt; '.
             '&lt;http://purl.org/dc/elements/1.1/title&gt; '.
             '&quot;World Wide Web Consortium&quot; .',
@@ -89,25 +89,25 @@ class ConverterTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf Converter</title>', $output);
-        $this->assertContains('<h1>EasyRdf Converter</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Converter</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Converter</h1>', $output);
+        $this->assertStringContainsString(
             '&lt;http://www.w3.org/TR/rdf-syntax-grammar&gt; '.
             '&lt;http://purl.org/dc/elements/1.1/title&gt; '.
             '&quot;RDF/XML Syntax Specification (Revised)&quot; .',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '&lt;http://www.w3.org/TR/rdf-syntax-grammar&gt; '.
             '&lt;http://example.org/stuff/1.0/editor&gt; _:genid1 .',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '_:genid1 &lt;http://example.org/stuff/1.0/fullname&gt; '.
             '&quot;Dave Beckett&quot; .',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '_:genid1 &lt;http://example.org/stuff/1.0/homePage&gt; '.
             '&lt;http://purl.org/net/dajobe/&gt; .',
             $output

--- a/test/examples/DumpTest.php
+++ b/test/examples/DumpTest.php
@@ -43,8 +43,8 @@ class DumpTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('dump.php');
-        $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
-        $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
     }
 
     public function testDumpHTML()
@@ -57,12 +57,15 @@ class DumpTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
-        $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);
-        $this->assertContains('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
-        $this->assertContains("color:blue'>http://example/q?abc=1&amp;def=2</a>", $output);
-        $this->assertContains("color:green'>rdf:value</span>", $output);
-        $this->assertContains("color:black'>&quot;xxx&quot;</span>", $output);
+        $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
+        $this->assertStringContainsString(
+            'Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf',
+            $output
+        );
+        $this->assertStringContainsString("color:blue'>http://example/q?abc=1&amp;def=2</a>", $output);
+        $this->assertStringContainsString("color:green'>rdf:value</span>", $output);
+        $this->assertStringContainsString("color:black'>&quot;xxx&quot;</span>", $output);
     }
 
     public function testDumpText()
@@ -74,10 +77,13 @@ class DumpTest extends \EasyRdf\TestCase
                 'format' => 'text'
             )
         );
-        $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
-        $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);
-        $this->assertContains('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
-        $this->assertContains('http://example/q?abc=1&def=2 (EasyRdf\Resource)', $output);
-        $this->assertContains('-> rdf:value -> "xxx"', $output);
+        $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
+        $this->assertStringContainsString(
+            'Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf',
+            $output
+        );
+        $this->assertStringContainsString('http://example/q?abc=1&def=2 (EasyRdf\Resource)', $output);
+        $this->assertStringContainsString('-> rdf:value -> "xxx"', $output);
     }
 }

--- a/test/examples/FoafinfoTest.php
+++ b/test/examples/FoafinfoTest.php
@@ -43,9 +43,9 @@ class FoafinfoTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('foafinfo.php');
-        $this->assertContains('<title>EasyRdf FOAF Info Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Info Example</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf FOAF Info Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Info Example</h1>', $output);
+        $this->assertStringContainsString(
             '<input type="text" name="uri" id="uri" value="http://njh.me/foaf.rdf" size="50" />',
             $output
         );
@@ -58,19 +58,19 @@ class FoafinfoTest extends \EasyRdf\TestCase
             array('uri' => 'http://njh.me/foaf.rdf')
         );
 
-        $this->assertContains('<title>EasyRdf FOAF Info Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Info Example</h1>', $output);
-        $this->assertContains("<dt>Name:</dt><dd>Nicholas J Humfrey</dd>", $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf FOAF Info Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Info Example</h1>', $output);
+        $this->assertStringContainsString("<dt>Name:</dt><dd>Nicholas J Humfrey</dd>", $output);
+        $this->assertStringContainsString(
             "<dt>Homepage:</dt><dd><a href=\"http://www.aelius.com/njh/\">http://www.aelius.com/njh/</a></dd>",
             $output
         );
 
-        $this->assertContains("<h2>Known Persons</h2>", $output);
-        $this->assertContains(">Patrick Sinclair</a></li>", $output);
-        $this->assertContains(">Yves Raimond</a></li>", $output);
+        $this->assertStringContainsString("<h2>Known Persons</h2>", $output);
+        $this->assertStringContainsString(">Patrick Sinclair</a></li>", $output);
+        $this->assertStringContainsString(">Yves Raimond</a></li>", $output);
 
-        $this->assertContains("<h2>Interests</h2>", $output);
-        $this->assertContains(">RDF</a></li>", $output);
+        $this->assertStringContainsString("<h2>Interests</h2>", $output);
+        $this->assertStringContainsString(">RDF</a></li>", $output);
     }
 }

--- a/test/examples/FoafmakerTest.php
+++ b/test/examples/FoafmakerTest.php
@@ -43,8 +43,8 @@ class FoafmakerTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('foafmaker.php');
-        $this->assertContains('<title>EasyRdf FOAF Maker Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Maker Example</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf FOAF Maker Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Maker Example</h1>', $output);
     }
 
     public function testJoeBloggs()
@@ -67,9 +67,9 @@ class FoafmakerTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf FOAF Maker Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Maker Example</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf FOAF Maker Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Maker Example</h1>', $output);
+        $this->assertStringContainsString(
             "@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .\n\n".
             "&lt;http://www.example.com/joe#me&gt;\n".
             "  a foaf:Person ;\n".

--- a/test/examples/GraphdirectTest.php
+++ b/test/examples/GraphdirectTest.php
@@ -43,25 +43,25 @@ class GraphdirectTest extends \EasyRdf\TestCase
     public function test()
     {
         $output = executeExample('graph_direct.php');
-        $this->assertContains('<title>Example of using EasyRdf\\Graph directly</title>', $output);
+        $this->assertStringContainsString('<title>Example of using EasyRdf\\Graph directly</title>', $output);
 
-        $this->assertContains('<b>Name:</b> Joe Bloggs <br />', $output);
-        $this->assertContains('<b>Names:</b> Joe Bloggs Joseph Bloggs <br />', $output);
+        $this->assertStringContainsString('<b>Name:</b> Joe Bloggs <br />', $output);
+        $this->assertStringContainsString('<b>Names:</b> Joe Bloggs Joseph Bloggs <br />', $output);
 
-        $this->assertContains('<b>Label:</b> Nick <br />', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<b>Label:</b> Nick <br />', $output);
+        $this->assertStringContainsString(
             '<b>Properties:</b> rdf:type, foaf:name, rdfs:label <br />',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<b>PropertyUris:</b> http://www.w3.org/1999/02/22-rdf-syntax-ns#type, '.
             'http://xmlns.com/foaf/0.1/name, http://www.w3.org/2000/01/rdf-schema#label <br />',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<b>People:</b> http://example.com/joe, http://njh.me/ <br />',
             $output
         );
-        $this->assertContains('<b>Unknown:</b>  <br />', $output);
+        $this->assertStringContainsString('<b>Unknown:</b>  <br />', $output);
     }
 }

--- a/test/examples/HttpgetTest.php
+++ b/test/examples/HttpgetTest.php
@@ -43,17 +43,17 @@ class HttpgetTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('httpget.php');
-        $this->assertContains('<title>Test EasyRdf HTTP Client Get</title>', $output);
-        $this->assertContains('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>Test EasyRdf HTTP Client Get</title>', $output);
+        $this->assertStringContainsString('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
+        $this->assertStringContainsString(
             '<input type="text" name="uri" id="uri" value="http://tomheath.com/id/me" size="50" />',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="application/rdf+xml">application/rdf+xml</option>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="text/html">text/html</option>',
             $output
         );
@@ -68,10 +68,10 @@ class HttpgetTest extends \EasyRdf\TestCase
                 'accept' => 'text/html'
             )
         );
-        $this->assertContains('<title>Test EasyRdf HTTP Client Get</title>', $output);
-        $this->assertContains('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
-        $this->assertContains('<b>Content-type</b>: text/html', $output);
-        $this->assertContains('&lt;h1&gt;Home - Tom Heath&lt;/h1&gt;', $output);
+        $this->assertStringContainsString('<title>Test EasyRdf HTTP Client Get</title>', $output);
+        $this->assertStringContainsString('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
+        $this->assertStringContainsString('<b>Content-type</b>: text/html', $output);
+        $this->assertStringContainsString('&lt;h1&gt;Home - Tom Heath&lt;/h1&gt;', $output);
     }
 
     public function testRdfXml()
@@ -83,10 +83,10 @@ class HttpgetTest extends \EasyRdf\TestCase
                 'accept' => 'application/rdf+xml'
             )
         );
-        $this->assertContains('<title>Test EasyRdf HTTP Client Get</title>', $output);
-        $this->assertContains('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
-        $this->assertContains('<b>Content-type</b>: application/rdf+xml', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>Test EasyRdf HTTP Client Get</title>', $output);
+        $this->assertStringContainsString('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
+        $this->assertStringContainsString('<b>Content-type</b>: application/rdf+xml', $output);
+        $this->assertStringContainsString(
             '&lt;foaf:Person rdf:about=&quot;http://tomheath.com/id/me&quot;&gt;',
             $output
         );

--- a/test/examples/OpenGraphProtocolTest.php
+++ b/test/examples/OpenGraphProtocolTest.php
@@ -43,9 +43,12 @@ class OpenGraphProtocolTest extends \EasyRdf\TestCase
     public function testRottenTomatoes()
     {
         $output = executeExample('open_graph_protocol.php');
-        $this->assertContains('<dd><a href="https://www.rottentomatoes.com/m/oceans_eleven"', $output);
-        $this->assertContains('<dt>Title:</dt> <dd>Ocean\'s Eleven (2001)</dd>', $output);
-        $this->assertContains('<dt>Description:</dt> <dd>A rag-tag group of con artists and ex-cons', $output);
-        $this->assertContains('src="https://resizing.flixster.com/', $output);
+        $this->assertStringContainsString('<dd><a href="https://www.rottentomatoes.com/m/oceans_eleven"', $output);
+        $this->assertStringContainsString('<dt>Title:</dt> <dd>Ocean\'s Eleven (2001)</dd>', $output);
+        $this->assertStringContainsString(
+            '<dt>Description:</dt> <dd>A rag-tag group of con artists and ex-cons',
+            $output
+        );
+        $this->assertStringContainsString('src="https://resizing.flixster.com/', $output);
     }
 }

--- a/test/examples/ParseRssTest.php
+++ b/test/examples/ParseRssTest.php
@@ -43,8 +43,8 @@ class ParseRssTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('parse_rss.php');
-        $this->assertContains('<title>EasyRdf RSS 1.0 Parsing example</title>', $output);
-        $this->assertContains('<h1>EasyRdf RSS 1.0 Parsing example</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf RSS 1.0 Parsing example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf RSS 1.0 Parsing example</h1>', $output);
     }
 
     public function testPlanetRdf()
@@ -53,15 +53,15 @@ class ParseRssTest extends \EasyRdf\TestCase
             'parse_rss.php',
             array('uri' => 'http://planetrdf.com/index.rdf')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<p>Channel: <a href="http://planetrdf.com/">Planet RDF</a></p>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<p>Description: It's triples all the way down</p>",
             $output
         );
-        $this->assertContains('<li><a href="https://', $output);
-        $this->assertContains('</a></li>', $output);
+        $this->assertStringContainsString('<li><a href="https://', $output);
+        $this->assertStringContainsString('</a></li>', $output);
     }
 }

--- a/test/examples/SerialiseTest.php
+++ b/test/examples/SerialiseTest.php
@@ -46,8 +46,8 @@ class SerialiseTest extends \EasyRdf\TestCase
             'serialise.php',
             array('format' => 'ntriples')
         );
-        $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
+        $this->assertStringContainsString(
             '&lt;http://www.example.com/joe#me&gt; '.
             '&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; '.
             '&lt;http://xmlns.com/foaf/0.1/Person&gt; .',
@@ -61,8 +61,8 @@ class SerialiseTest extends \EasyRdf\TestCase
             'serialise.php',
             array('format' => 'rdfxml')
         );
-        $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
+        $this->assertStringContainsString(
             '&lt;foaf:Person rdf:about=&quot;http://www.example.com/joe#me&quot;&gt;',
             $output
         );
@@ -74,7 +74,7 @@ class SerialiseTest extends \EasyRdf\TestCase
             'serialise.php',
             array('format' => 'php')
         );
-        $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
-        $this->assertContains("'value' =&gt; 'http://xmlns.com/foaf/0.1/Person',", $output);
+        $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
+        $this->assertStringContainsString("'value' =&gt; 'http://xmlns.com/foaf/0.1/Person',", $output);
     }
 }

--- a/test/examples/SparqlqueryformTest.php
+++ b/test/examples/SparqlqueryformTest.php
@@ -43,9 +43,9 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('sparql_queryform.php');
-        $this->assertContains('<title>EasyRdf SPARQL Query Form</title>', $output);
-        $this->assertContains('<h1>EasyRdf SPARQL Query Form</h1>', $output);
-        $this->assertContains('PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;', $output);
+        $this->assertStringContainsString('<title>EasyRdf SPARQL Query Form</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf SPARQL Query Form</h1>', $output);
+        $this->assertStringContainsString('PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;', $output);
     }
 
     public function testDbpediaCountries()
@@ -64,8 +64,8 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
                     '} ORDER BY ?label LIMIT 100'
             )
         );
-        $this->assertContains('>http://dbpedia.org/resource/China</a>', $output);
-        $this->assertContains('>&quot;China&quot;@en</span>', $output);
+        $this->assertStringContainsString('>http://dbpedia.org/resource/China</a>', $output);
+        $this->assertStringContainsString('>&quot;China&quot;@en</span>', $output);
     }
 
     public function testDbpediaCountriesText()
@@ -86,7 +86,7 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('| http://dbpedia.org/resource/China', $output);
-        $this->assertContains('| &quot;China&quot;@en', $output);
+        $this->assertStringContainsString('| http://dbpedia.org/resource/China', $output);
+        $this->assertStringContainsString('| &quot;China&quot;@en', $output);
     }
 }

--- a/test/examples/UkpostcodeTest.php
+++ b/test/examples/UkpostcodeTest.php
@@ -43,8 +43,8 @@ class UkpostcodeTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('uk_postcode.php');
-        $this->assertContains('<title>EasyRdf UK Postcode Resolver</title>', $output);
-        $this->assertContains('<h1>EasyRdf UK Postcode Resolver</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf UK Postcode Resolver</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf UK Postcode Resolver</h1>', $output);
     }
 
     public function testW1A1AA()
@@ -53,13 +53,13 @@ class UkpostcodeTest extends \EasyRdf\TestCase
             'uk_postcode.php',
             array('postcode' => 'W1A 1AA')
         );
-        $this->assertContains('<tr><th>Longitude:</th><td>-0.143799</td></tr>', $output);
-        $this->assertContains('<tr><th>Latitude:</th><td>51.518561</td></tr>', $output);
-        $this->assertContains('<tr><th>Easting:</th><td>528887.0</td></tr>', $output);
-        $this->assertContains('<tr><th>Northing:</th><td>181593.0</td></tr>', $output);
-        $this->assertContains('<tr><th>District:</th><td>City of Westminster</td></tr>', $output);
-        $this->assertContains('<tr><th>Ward:</th><td>West End</td></tr>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<tr><th>Longitude:</th><td>-0.143799</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Latitude:</th><td>51.518561</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Easting:</th><td>528887.0</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Northing:</th><td>181593.0</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>District:</th><td>City of Westminster</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Ward:</th><td>West End</td></tr>', $output);
+        $this->assertStringContainsString(
             "src='https://www.openlinkmap.org/small.php?lat=51.518561&lon=-0.143799&zoom=14'",
             $output
         );

--- a/test/examples/WikidataVillagesTest.php
+++ b/test/examples/WikidataVillagesTest.php
@@ -43,10 +43,10 @@ class VillagesTest extends \EasyRdf\TestCase
     public function testIndex()
     {
         $output = executeExample('wikidata_villages.php');
-        $this->assertContains('<title>EasyRdf Village Info Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf Village Info Example</h1>', $output);
-        $this->assertContains('?id=Q33980">Ceres</a></li>', $output);
-        $this->assertContains('?id=Q1011990">Strathkinness</a></li>', $output);
+        $this->assertStringContainsString('<title>EasyRdf Village Info Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Village Info Example</h1>', $output);
+        $this->assertStringContainsString('?id=Q33980">Ceres</a></li>', $output);
+        $this->assertStringContainsString('?id=Q1011990">Strathkinness</a></li>', $output);
     }
 
     public function testCeres()
@@ -55,16 +55,16 @@ class VillagesTest extends \EasyRdf\TestCase
             'wikidata_villages.php',
             array('id' => 'Q33980')
         );
-        $this->assertContains('<h2>Ceres</h2>', $output);
-        $this->assertContains('<p>village in Fife, Scotland', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<h2>Ceres</h2>', $output);
+        $this->assertStringContainsString('<p>village in Fife, Scotland', $output);
+        $this->assertStringContainsString(
             '<img src="http://commons.wikimedia.org/wiki/Special:FilePath/Ceres%20in%20Fife.JPG"',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "src='http://www.openlinkmap.org/small.php?lat=56.29205&lon=-2.971445",
             $output
         );
-        $this->assertContains('<a href="https://en.wikipedia.org/wiki/Ceres,_Fife">', $output);
+        $this->assertStringContainsString('<a href="https://en.wikipedia.org/wiki/Ceres,_Fife">', $output);
     }
 }


### PR DESCRIPTION
PHP 8 got released, so I tried to see if there is already infrastructure available to test it with EasyRdf. Unfortunately I couldn't even start the tests. In this PR I would like to collect the things to do to make EasyRdf compatible to PHP 8.

---

First problem: Composer blocked installation because of Doctum and (one of) its dependencies, see: https://travis-ci.com/github/easyrdf/easyrdf/jobs/451389149#L207

```
Your requirements could not be resolved to an installable set of packages.
Problem 1
- code-lts/doctum[v5.0.0, ..., v5.2.1] require wdes/php-i18n-l10n ^2.0 -> satisfiable by wdes/php-i18n-l10n[2.0.0].
- wdes/php-i18n-l10n 2.0.0 requires php ^7.1 -> your php version (8.0.1-dev) does not satisfy that requirement.
- Root composer.json requires code-lts/doctum ^5 -> satisfiable by code-lts/doctum[v5.0.0, ..., v5.2.1].
```

I used `php: nightly` in `.travis.yml`.

@williamdes Are you aware of this? Any plans related to PHP 8?

Maybe also relevant: PHP 8.0 status in Travis itself, see: https://travis-ci.community/t/php-8-0-missing/10132/12