### PR TITLE
Test on PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /vendor
 /composer.phar
 /composer.lock
+/config/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       dist: bionic
     - php: 7.4
       dist: bionic
+    - php: 8.0
+      dist: bionic
 
 sudo: required
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,12 @@
     },
     "require-dev": {
         "ml/json-ld": "~1.0",
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^7 || ^8",
         "code-lts/doctum": "^5",
         "semsol/arc2": "^2.4",
         "squizlabs/php_codesniffer": "3.*",
-        "zendframework/zend-http": "~2.3"
+        "zendframework/zend-http": "~2.3",
+        "yoast/phpunit-polyfills": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/test/EasyRdf/CollectionTest.php
+++ b/test/EasyRdf/CollectionTest.php
@@ -40,13 +40,13 @@ require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class CollectionTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         RdfNamespace::set('ex', 'http://example.org/');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::delete('ex');
     }

--- a/test/EasyRdf/ContainerTest.php
+++ b/test/EasyRdf/ContainerTest.php
@@ -40,13 +40,13 @@ require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ContainerTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         RdfNamespace::set('ex', 'http://example.org/');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::delete('ex');
     }

--- a/test/EasyRdf/FormatTest.php
+++ b/test/EasyRdf/FormatTest.php
@@ -54,7 +54,7 @@ class FormatTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->format = Format::register(
             'my',
@@ -65,7 +65,7 @@ class FormatTest extends TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Format::unregister('my');
     }
@@ -100,7 +100,7 @@ class FormatTest extends TestCase
     public function testGetFormats()
     {
         $formats = Format::getFormats();
-        $this->assertInternalType('array', $formats);
+        $this->assertIsArray($formats);
         $this->assertGreaterThan(0, count($formats));
         foreach ($formats as $format) {
             $this->assertClass('EasyRdf\Format', $format);
@@ -110,15 +110,15 @@ class FormatTest extends TestCase
     public function testGetHttpAcceptHeader()
     {
         $accept = Format::getHttpAcceptHeader();
-        $this->assertContains('application/json', $accept);
-        $this->assertContains('application/rdf+xml;q=0.8', $accept);
+        $this->assertStringContainsString('application/json', $accept);
+        $this->assertStringContainsString('application/rdf+xml;q=0.8', $accept);
     }
 
     public function testGetHttpAcceptHeaderWithExtra()
     {
         $accept = Format::getHttpAcceptHeader(array('extra/header' => 0.5));
-        $this->assertContains('application/json', $accept);
-        $this->assertContains('extra/header;q=0.5', $accept);
+        $this->assertStringContainsString('application/json', $accept);
+        $this->assertStringContainsString('extra/header;q=0.5', $accept);
     }
 
     public function testGetHttpAcceptHeaderLocale()
@@ -127,7 +127,7 @@ class FormatTest extends TestCase
         setlocale(LC_NUMERIC, 'fi_FI.UTF-8');
 
         $accept = Format::getHttpAcceptHeader(array('extra/header' => 0.5));
-        $this->assertContains('extra/header;q=0.5', $accept);
+        $this->assertStringContainsString('extra/header;q=0.5', $accept);
 
         setlocale(LC_NUMERIC, $current_locale);
     }
@@ -469,7 +469,7 @@ class FormatTest extends TestCase
     {
         $this->format->setParserClass('EasyRdf\MockParserClass');
         $parser = $this->format->newParser();
-        $this->assertInternalType('object', $parser);
+        $this->assertIsObject($parser);
         $this->assertClass('EasyRdf\MockParserClass', $parser);
     }
 
@@ -517,7 +517,7 @@ class FormatTest extends TestCase
     {
         $this->format->setSerialiserClass('EasyRdf\MockSerialiserClass');
         $serialiser = $this->format->newSerialiser();
-        $this->assertInternalType('object', $serialiser);
+        $this->assertIsObject($serialiser);
         $this->assertClass('EasyRdf\MockSerialiserClass', $serialiser);
     }
 

--- a/test/EasyRdf/GraphStoreTest.php
+++ b/test/EasyRdf/GraphStoreTest.php
@@ -48,7 +48,7 @@ class GraphStoreTest extends TestCase
     /** @var MockClient */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         Http::setDefaultHttpClient(
             $this->client = new MockClient()

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -72,7 +72,7 @@ class GraphTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         // Reset to built-in parsers
         Format::registerParser('ntriples', 'EasyRdf\Parser\Ntriples');
@@ -275,7 +275,7 @@ class GraphTest extends TestCase
     public function testLoadWithContentType()
     {
         $checkRequest = function ($client) {
-            $this->assertContains(",application/json,", $client->getHeader('Accept'));
+            $this->assertStringContainsString(",application/json,", $client->getHeader('Accept'));
             return true;
         };
         $this->client->addMockOnce(
@@ -1853,26 +1853,26 @@ class GraphTest extends TestCase
     public function testDumpText()
     {
         $text = $this->graph->dump('text');
-        $this->assertContains('Graph: http://example.com/graph', $text);
-        $this->assertContains('http://example.com/#me (EasyRdf\Resource)', $text);
-        $this->assertContains('  -> rdf:type -> foaf:Person', $text);
-        $this->assertContains('  -> rdf:test -> "Test A"', $text);
+        $this->assertStringContainsString('Graph: http://example.com/graph', $text);
+        $this->assertStringContainsString('http://example.com/#me (EasyRdf\Resource)', $text);
+        $this->assertStringContainsString('  -> rdf:type -> foaf:Person', $text);
+        $this->assertStringContainsString('  -> rdf:test -> "Test A"', $text);
     }
 
     public function testDumpEmptyGraph()
     {
         $graph = new Graph('http://example.com/graph2');
         $this->assertSame("Graph: http://example.com/graph2\n", $graph->dump('text'));
-        $this->assertContains('>Graph: http://example.com/graph2</div>', $graph->dump('html'));
+        $this->assertStringContainsString('>Graph: http://example.com/graph2</div>', $graph->dump('html'));
     }
 
     public function testDumpHtml()
     {
         $html = $this->graph->dump('html');
-        $this->assertContains('Graph: http://example.com/graph', $html);
-        $this->assertContains('http://example.com/#me', $html);
-        $this->assertContains('>rdf:test</span>', $html);
-        $this->assertContains('>&quot;Test A&quot;</span>', $html);
+        $this->assertStringContainsString('Graph: http://example.com/graph', $html);
+        $this->assertStringContainsString('http://example.com/#me', $html);
+        $this->assertStringContainsString('>rdf:test</span>', $html);
+        $this->assertStringContainsString('>&quot;Test A&quot;</span>', $html);
     }
 
     public function testDumpLiterals()
@@ -1885,22 +1885,22 @@ class GraphTest extends TestCase
         $graph->add('http://example.com/joe#me', '<http://v.example.com/foo>', 'bar');
 
         $text = $graph->dump('text');
-        $this->assertContains('http://example.com/joe#me', $text);
-        $this->assertContains('-> foaf:name -> "Joe"', $text);
-        $this->assertContains('-> foaf:age -> "52"^^xsd:integer', $text);
-        $this->assertContains('-> foaf:birthPlace -> "Deutschland"@de', $text);
-        $this->assertContains('-> <http://v.example.com/foo> -> "bar"', $text);
+        $this->assertStringContainsString('http://example.com/joe#me', $text);
+        $this->assertStringContainsString('-> foaf:name -> "Joe"', $text);
+        $this->assertStringContainsString('-> foaf:age -> "52"^^xsd:integer', $text);
+        $this->assertStringContainsString('-> foaf:birthPlace -> "Deutschland"@de', $text);
+        $this->assertStringContainsString('-> <http://v.example.com/foo> -> "bar"', $text);
 
         $html = $graph->dump('html');
-        $this->assertContains('http://example.com/joe#me', $html);
-        $this->assertContains('>foaf:name</span>', $html);
-        $this->assertContains('>&quot;Joe&quot;</span>', $html);
-        $this->assertContains('>foaf:age</span>', $html);
-        $this->assertContains('>&quot;52&quot;^^xsd:integer</span>', $html);
-        $this->assertContains('>foaf:birthPlace</span>', $html);
-        $this->assertContains('>&quot;Deutschland&quot;@de</span>', $html);
-        $this->assertContains('>&lt;http://v.example.com/foo&gt;</span>', $html);
-        $this->assertContains('>&quot;bar&quot;</span>', $html);
+        $this->assertStringContainsString('http://example.com/joe#me', $html);
+        $this->assertStringContainsString('>foaf:name</span>', $html);
+        $this->assertStringContainsString('>&quot;Joe&quot;</span>', $html);
+        $this->assertStringContainsString('>foaf:age</span>', $html);
+        $this->assertStringContainsString('>&quot;52&quot;^^xsd:integer</span>', $html);
+        $this->assertStringContainsString('>foaf:birthPlace</span>', $html);
+        $this->assertStringContainsString('>&quot;Deutschland&quot;@de</span>', $html);
+        $this->assertStringContainsString('>&lt;http://v.example.com/foo&gt;</span>', $html);
+        $this->assertStringContainsString('>&quot;bar&quot;</span>', $html);
     }
 
     public function testDumpResource()
@@ -1911,19 +1911,19 @@ class GraphTest extends TestCase
         $graph->add('http://example.com/joe#me', 'foaf:knows', $graph->newBnode());
 
         $text = $graph->dumpResource('http://example.com/joe#me', 'text');
-        $this->assertContains('http://example.com/joe#me', $text);
-        $this->assertContains('-> rdf:type -> foaf:Person', $text);
-        $this->assertContains('-> foaf:homepage -> http://example.com/', $text);
-        $this->assertContains('-> foaf:knows -> _:genid1', $text);
+        $this->assertStringContainsString('http://example.com/joe#me', $text);
+        $this->assertStringContainsString('-> rdf:type -> foaf:Person', $text);
+        $this->assertStringContainsString('-> foaf:homepage -> http://example.com/', $text);
+        $this->assertStringContainsString('-> foaf:knows -> _:genid1', $text);
 
         $html = $graph->dumpResource('http://example.com/joe#me', 'html');
-        $this->assertContains('http://example.com/joe#me', $html);
-        $this->assertContains('>rdf:type</span>', $html);
-        $this->assertContains('>foaf:Person</a>', $html);
-        $this->assertContains('>foaf:homepage</span>', $html);
-        $this->assertContains('>http://example.com/</a>', $html);
-        $this->assertContains('>foaf:knows</span>', $html);
-        $this->assertContains('>_:genid1</a>', $html);
+        $this->assertStringContainsString('http://example.com/joe#me', $html);
+        $this->assertStringContainsString('>rdf:type</span>', $html);
+        $this->assertStringContainsString('>foaf:Person</a>', $html);
+        $this->assertStringContainsString('>foaf:homepage</span>', $html);
+        $this->assertStringContainsString('>http://example.com/</a>', $html);
+        $this->assertStringContainsString('>foaf:knows</span>', $html);
+        $this->assertStringContainsString('>_:genid1</a>', $html);
     }
 
     public function testDumpResourceWithNoProperties()
@@ -1937,7 +1937,7 @@ class GraphTest extends TestCase
     {
         $graph = new Graph();
         $graph->addType("wikibase_id:Q' onload='alert(1234)", 'foaf:Person');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<div id='wikibase_id:Q&#039; onload=&#039;alert(1234)' ".
             "style='font-family:arial; padding:0.5em; background-color:lightgrey;border:dashed 1px grey;'>",
             $graph->dumpResource("wikibase_id:Q' onload='alert(1234)")

--- a/test/EasyRdf/Http/ClientTest.php
+++ b/test/EasyRdf/Http/ClientTest.php
@@ -55,7 +55,7 @@ class ClientTest extends TestCase
      * Set up the test suite before each test
      *
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new Client('http://www.example.com/');
     }

--- a/test/EasyRdf/Http/MockClientTest.php
+++ b/test/EasyRdf/Http/MockClientTest.php
@@ -47,7 +47,7 @@ class MockClientTest extends TestCase
     /** @var MockClient */
     private $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client = new MockClient();
     }

--- a/test/EasyRdf/IsomorphicTest.php
+++ b/test/EasyRdf/IsomorphicTest.php
@@ -48,7 +48,7 @@ class IsomorphicTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->graphA = new Graph();
         $this->graphB = new Graph();

--- a/test/EasyRdf/Literal/BooleanTest.php
+++ b/test/EasyRdf/Literal/BooleanTest.php
@@ -47,7 +47,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('true');
         $this->assertStringEquals('true', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -57,7 +57,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('false');
         $this->assertStringEquals('false', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -67,7 +67,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('1');
         $this->assertStringEquals('1', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -77,7 +77,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean('0');
         $this->assertStringEquals('0', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -87,7 +87,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(true);
         $this->assertStringEquals('true', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -97,7 +97,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(false);
         $this->assertStringEquals('false', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -107,7 +107,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(1);
         $this->assertStringEquals('true', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(true, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
@@ -117,7 +117,7 @@ class BooleanTest extends TestCase
     {
         $literal = new Boolean(0);
         $this->assertStringEquals('false', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(false, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());

--- a/test/EasyRdf/Literal/DateTimeTest.php
+++ b/test/EasyRdf/Literal/DateTimeTest.php
@@ -105,7 +105,7 @@ class DateTimeTest extends TestCase
 
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->dt = new DateTime('2010-09-08T07:06:05Z');
     }

--- a/test/EasyRdf/Literal/DecimalTest.php
+++ b/test/EasyRdf/Literal/DecimalTest.php
@@ -46,7 +46,7 @@ class DecimalTest extends TestCase
     public function testConstruct15()
     {
         $literal = new Decimal(1.5);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         $this->assertSame('1.5', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
@@ -60,7 +60,7 @@ class DecimalTest extends TestCase
 
         try {
             $literal = new Decimal(1.5);
-            $this->assertInternalType('string', $literal->getValue());
+            $this->assertIsString($literal->getValue());
             $this->assertSame('1.5', $literal->getValue());
             $this->assertSame(null, $literal->getLang());
             $this->assertSame('xsd:decimal', $literal->getDatatype());
@@ -75,7 +75,7 @@ class DecimalTest extends TestCase
     public function testConstructString100()
     {
         $literal = new Decimal('100.00');
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         $this->assertSame('100.0', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:decimal', $literal->getDatatype());

--- a/test/EasyRdf/Literal/HTMLTest.php
+++ b/test/EasyRdf/Literal/HTMLTest.php
@@ -48,7 +48,7 @@ class HTMLTest extends TestCase
         $literal = new HTML('<p>Hello World</p>');
         $this->assertClass('EasyRdf\Literal\HTML', $literal);
         $this->assertStringEquals('<p>Hello World</p>', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         $this->assertSame('<p>Hello World</p>', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('rdf:HTML', $literal->getDatatype());

--- a/test/EasyRdf/Literal/HexBinaryTest.php
+++ b/test/EasyRdf/Literal/HexBinaryTest.php
@@ -45,7 +45,7 @@ require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
 
 class HexBinaryTest extends TestCase
 {
-    public function setup()
+    public function setUp(): void
     {
         // Reset to built-in parsers
         Format::registerParser('ntriples', 'EasyRdf\Parser\Ntriples');
@@ -57,7 +57,7 @@ class HexBinaryTest extends TestCase
     {
         $literal = new HexBinary('48656C6C6F');
         $this->assertStringEquals('48656C6C6F', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         $this->assertSame('48656C6C6F', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:hexBinary', $literal->getDatatype());
@@ -132,7 +132,7 @@ class HexBinaryTest extends TestCase
             '71FD4F207AD770809E0E2D7B0EF5493BEFE73544D8E1BE3DDDB52455C61391A1',
             $modulus
         );
-        $this->assertInternalType('string', $modulus->getValue());
+        $this->assertIsString($modulus->getValue());
         $this->assertSame(null, $modulus->getLang());
         $this->assertSame('xsd:hexBinary', $modulus->getDatatype());
     }

--- a/test/EasyRdf/Literal/IntegerTest.php
+++ b/test/EasyRdf/Literal/IntegerTest.php
@@ -48,7 +48,7 @@ class IntegerTest extends TestCase
         $literal = new Integer(0);
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('0', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertIsInt($literal->getValue());
         $this->assertSame(0, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
@@ -59,7 +59,7 @@ class IntegerTest extends TestCase
         $literal = new Integer(1);
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('1', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertIsInt($literal->getValue());
         $this->assertSame(1, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
@@ -70,7 +70,7 @@ class IntegerTest extends TestCase
         $literal = new Integer('100');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('100', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertIsInt($literal->getValue());
         $this->assertSame(100, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
@@ -81,7 +81,7 @@ class IntegerTest extends TestCase
         $literal = new Integer('0100');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertStringEquals('0100', $literal);
-        $this->assertInternalType('int', $literal->getValue());
+        $this->assertIsInt($literal->getValue());
         $this->assertSame(100, $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());

--- a/test/EasyRdf/Literal/XMLTest.php
+++ b/test/EasyRdf/Literal/XMLTest.php
@@ -48,7 +48,7 @@ class XMLTest extends TestCase
         $literal = new XML('<tag>Hello World</tag>');
         $this->assertClass('EasyRdf\Literal\XML', $literal);
         $this->assertStringEquals('<tag>Hello World</tag>', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         $this->assertSame('<tag>Hello World</tag>', $literal->getValue());
         $this->assertSame(null, $literal->getLang());
         $this->assertSame('rdf:XMLLiteral', $literal->getDatatype());

--- a/test/EasyRdf/LiteralTest.php
+++ b/test/EasyRdf/LiteralTest.php
@@ -48,12 +48,12 @@ class MyDatatypeClass extends Literal
 
 class LiteralTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         RdfNamespace::set('ex', 'http://www.example.com/');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Literal::deleteDatatypeMapping('ex:mytype');
         RdfNamespace::delete('ex');
@@ -242,7 +242,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(1, null, 'xsd:boolean');
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(true, $literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -252,7 +252,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(0, null, 'xsd:boolean');
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
-        $this->assertInternalType('bool', $literal->getValue());
+        $this->assertIsBool($literal->getValue());
         $this->assertSame(false, $literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -262,7 +262,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create('100.00', null, 'xsd:integer');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
-        $this->assertInternalType('integer', $literal->getValue());
+        $this->assertIsInt($literal->getValue());
         $this->assertSame(100, $literal->getValue());
         $this->assertSame('xsd:integer', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -272,7 +272,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create('1', null, 'xsd:decimal');
         $this->assertClass('EasyRdf\Literal\Decimal', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         $this->assertSame('1.0', $literal->getValue());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
         $this->assertSame(null, $literal->getLang());
@@ -282,7 +282,7 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(true, null, 'xsd:string');
         $this->assertClass('EasyRdf\Literal', $literal);
-        $this->assertInternalType('string', $literal->getValue());
+        $this->assertIsString($literal->getValue());
         # Hmm, not sure about this, but PHP does the conversion not me:
         $this->assertSame('1', $literal->getValue());
         $this->assertSame('xsd:string', $literal->getDatatype());

--- a/test/EasyRdf/NamespaceTest.php
+++ b/test/EasyRdf/NamespaceTest.php
@@ -45,14 +45,14 @@ class NamespaceTest extends TestCase
     /** @var Resource */
     private $resource;
 
-    public function setUp()
+    public function setUp(): void
     {
         RdfNamespace::setDefault(null);
         $this->graph = new Graph();
         $this->resource = $this->graph->resource('http://xmlns.com/foaf/0.1/name');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::delete('po');
         RdfNamespace::reset();

--- a/test/EasyRdf/ParsedUriTest.php
+++ b/test/EasyRdf/ParsedUriTest.php
@@ -43,7 +43,7 @@ class ParsedUriTest extends TestCase
     /** @var ParsedUri */
     private $baseUri;
 
-    public function setup()
+    public function setUp(): void
     {
         $this->baseUri = new ParsedUri(
             'http://a/b/c/d;p?q'

--- a/test/EasyRdf/Parser/ArcTest.php
+++ b/test/EasyRdf/Parser/ArcTest.php
@@ -50,7 +50,7 @@ class ArcTest extends TestCase
     protected $graph = null;
     protected $data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (class_exists('ARC2')) {
             $this->parser = new Arc();

--- a/test/EasyRdf/Parser/JsonLdTest.php
+++ b/test/EasyRdf/Parser/JsonLdTest.php
@@ -59,7 +59,7 @@ class JsonLdTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new JsonLd();

--- a/test/EasyRdf/Parser/JsonTest.php
+++ b/test/EasyRdf/Parser/JsonTest.php
@@ -50,7 +50,7 @@ class JsonTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new Json();

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -50,7 +50,7 @@ class NtriplesTest extends TestCase
     protected $graph = null;
     protected $nt_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new Ntriples();

--- a/test/EasyRdf/Parser/RapperTest.php
+++ b/test/EasyRdf/Parser/RapperTest.php
@@ -50,7 +50,7 @@ class RapperTest extends TestCase
     protected $graph = null;
     protected $rdf_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         exec('rapper --version 2>/dev/null', $output, $retval);
         if ($retval == 0) {

--- a/test/EasyRdf/Parser/RdfPhpTest.php
+++ b/test/EasyRdf/Parser/RdfPhpTest.php
@@ -50,7 +50,7 @@ class RdfPhpTest extends TestCase
     protected $graph = null;
     protected $rdf_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new RdfPhp();
@@ -133,46 +133,46 @@ class RdfPhpTest extends TestCase
 
     /**
      * 'foo' is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput1()
     {
+        $this->expectException(Exception::class);
         $this->parser->parse($this->graph, 'foo', 'php', null);
     }
 
     /**
      * list of strings is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput2()
     {
+        $this->expectException(Exception::class);
         $this->parser->parse($this->graph, array('foo', 'bar'), 'php', null);
     }
 
     /**
      * 1-level dictionary of strings is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput3()
     {
+        $this->expectException(Exception::class);
         $this->parser->parse($this->graph, array('foo' => 'bar'), 'php', null);
     }
 
     /**
      * 2-level dictionary of strings is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput4()
     {
+        $this->expectException(Exception::class);
         $this->parser->parse($this->graph, array('foo' => array('bar' => 'baz')), 'php', null);
     }
 
     /**
      * 2-level dictionary of incorrect arrays is not a valid input for RdfPhp
-     * @expectedException Exception
      */
     public function testParseInvalidInput5()
     {
+        $this->expectException(Exception::class);
         $this->parser->parse($this->graph, array('foo' => array('bar' => array('baz' => 'buzz'))), 'php', null);
     }
 }

--- a/test/EasyRdf/Parser/RdfXmlTest.php
+++ b/test/EasyRdf/Parser/RdfXmlTest.php
@@ -50,7 +50,7 @@ class RdfXmlTest extends TestCase
     protected $graph = null;
     protected $rdf_data = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->parser = new RdfXml();

--- a/test/EasyRdf/Parser/RdfaTest.php
+++ b/test/EasyRdf/Parser/RdfaTest.php
@@ -53,7 +53,7 @@ class RdfaTest extends TestCase
     protected $baseUri;
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rdfaParser = new Rdfa();
         $this->ntriplesParser = new Ntriples();

--- a/test/EasyRdf/Parser/TurtleTest.php
+++ b/test/EasyRdf/Parser/TurtleTest.php
@@ -53,7 +53,7 @@ class TurtleTest extends TestCase
 
     protected $baseUri;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->turtleParser = new Turtle();
         $this->ntriplesParser = new Ntriples();

--- a/test/EasyRdf/ParserTest.php
+++ b/test/EasyRdf/ParserTest.php
@@ -59,7 +59,7 @@ class ParserTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->resource = $this->graph->resource('http://www.example.com/');

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -51,7 +51,7 @@ class ResourceTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         // Reset default namespace
         RdfNamespace::setDefault(null);
@@ -1202,45 +1202,45 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $text = $this->resource->dump('text');
-        $this->assertContains(
+        $this->assertStringContainsString(
             'http://example.com/#me (EasyRdf\Resource)',
             $text
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '-> rdf:type -> foaf:Person',
             $text
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '-> rdf:test -> "Test A", "Test B"@en',
             $text
         );
 
         $html = $this->resource->dump();
-        $this->assertContains("<div id='http://example.com/#me'", $html);
-        $this->assertContains(
+        $this->assertStringContainsString("<div id='http://example.com/#me'", $html);
+        $this->assertStringContainsString(
             "<a href='http://example.com/#me' ".
             "style='text-decoration:none;color:blue'>".
             "http://example.com/#me</a>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='text-decoration:none;color:green'>rdf:type</span>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<a href='http://xmlns.com/foaf/0.1/Person' ".
             "style='text-decoration:none;color:blue'>foaf:Person</a>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='text-decoration:none;color:green'>rdf:test</span>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='color:black'>&quot;Test A&quot;</span>",
             $html
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<span style='color:black'>&quot;Test B&quot;@en</span>",
             $html
         );

--- a/test/EasyRdf/Serialiser/ArcTest.php
+++ b/test/EasyRdf/Serialiser/ArcTest.php
@@ -49,7 +49,7 @@ class ArcTest extends TestCase
     /** @var Arc */
     private $serialiser;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (class_exists('ARC2')) {
             $this->graph = new Graph();
@@ -72,11 +72,11 @@ class ArcTest extends TestCase
 
         $rdfxml = $this->serialiser->serialise($this->graph, 'rdfxml');
         $this->assertNotNull($rdfxml);
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<rdf:Description rdf:about="http://www.example.com/joe#me">',
             $rdfxml
         );
-        $this->assertContains(':name>Project Name<', $rdfxml);
+        $this->assertStringContainsString(':name>Project Name<', $rdfxml);
     }
 
     public function testSerialiseUnsupportedFormat()

--- a/test/EasyRdf/Serialiser/GraphVizTest.php
+++ b/test/EasyRdf/Serialiser/GraphVizTest.php
@@ -49,7 +49,7 @@ class GraphVizTest extends TestCase
     /** @var GraphViz */
     private $serialiser;
 
-    public function setUp()
+    public function setUp(): void
     {
         exec('which dot 2>&1', $output, $retval);
         if ($retval == 0) {

--- a/test/EasyRdf/Serialiser/JsonLdTest.php
+++ b/test/EasyRdf/Serialiser/JsonLdTest.php
@@ -52,7 +52,7 @@ class JsonLdTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph('http://example.com/');
         $this->serialiser = new JsonLd();
@@ -86,7 +86,7 @@ class JsonLdTest extends TestCase
         $library->addResource('ex:contains', $book);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         RdfNamespace::resetNamespaces();
@@ -135,7 +135,7 @@ class JsonLdTest extends TestCase
         $decoded = json_decode($string, true);
 
         $this->assertArrayNotHasKey('@graph', $decoded);
-        $this->assertInternalType('array', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
+        $this->assertIsArray($decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
         $this->assertSame(59, $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@value']);
         $this->assertArrayNotHasKey('@type', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
 
@@ -145,7 +145,7 @@ class JsonLdTest extends TestCase
         $decoded = json_decode($string, true);
 
         $this->assertArrayNotHasKey('@graph', $decoded);
-        $this->assertInternalType('array', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
+        $this->assertIsArray($decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
         $this->assertSame('59', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@value']);
         $this->assertSame(
             'http://www.w3.org/2001/XMLSchema#integer',

--- a/test/EasyRdf/Serialiser/JsonTest.php
+++ b/test/EasyRdf/Serialiser/JsonTest.php
@@ -51,13 +51,13 @@ class JsonTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new Json();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         RdfNamespace::resetNamespaces();

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -52,13 +52,13 @@ class NtriplesTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new Ntriples();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         RdfNamespace::resetNamespaces();

--- a/test/EasyRdf/Serialiser/RapperTest.php
+++ b/test/EasyRdf/Serialiser/RapperTest.php
@@ -49,7 +49,7 @@ class RapperTest extends TestCase
     /** @var Rapper */
     private $serialiser;
 
-    public function setUp()
+    public function setUp(): void
     {
         exec('which rapper 2>&1', $output, $retval);
         if ($retval == 0) {

--- a/test/EasyRdf/Serialiser/RdfPhpTest.php
+++ b/test/EasyRdf/Serialiser/RdfPhpTest.php
@@ -50,7 +50,7 @@ class RdfPhpTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new RdfPhp();
@@ -69,20 +69,20 @@ class RdfPhpTest extends TestCase
         $joe->add('foaf:project', $project);
 
         $php = $this->serialiser->serialise($this->graph, 'php');
-        $this->assertInternalType('array', $php);
+        $this->assertIsArray($php);
         $subject = $php['http://www.example.com/joe#me'];
-        $this->assertInternalType('array', $subject);
+        $this->assertIsArray($subject);
         $type = $subject['http://www.w3.org/1999/02/22-rdf-syntax-ns#type'][0];
         $this->assertSame('uri', $type['type']);
         $this->assertSame('http://xmlns.com/foaf/0.1/Person', $type['value']);
         $name = $subject['http://xmlns.com/foaf/0.1/name'][0];
-        $this->assertInternalType('array', $name);
+        $this->assertIsArray($name);
         $this->assertSame('literal', $name['type']);
         $this->assertSame('Joe Bloggs', $name['value']);
         $this->assertFalse(isset($name['datatype']));
         $this->assertSame('en', $name['lang']);
         $age = $subject['http://xmlns.com/foaf/0.1/age'][0];
-        $this->assertInternalType('array', $age);
+        $this->assertIsArray($age);
         $this->assertSame('literal', $age['type']);
         $this->assertSame('59', $age['value']);
         $this->assertSame(
@@ -92,7 +92,7 @@ class RdfPhpTest extends TestCase
         $this->assertFalse(isset($age['lang']));
 
         $nodeid = $subject['http://xmlns.com/foaf/0.1/project'][0]['value'];
-        $this->assertInternalType('array', $php[$nodeid]);
+        $this->assertIsArray($php[$nodeid]);
         $projectName = $php[$nodeid]['http://xmlns.com/foaf/0.1/name'][0];
         $this->assertSame('Project Name', $projectName['value']);
         $this->assertFalse(isset($projectName['lang']));

--- a/test/EasyRdf/Serialiser/RdfXmlTest.php
+++ b/test/EasyRdf/Serialiser/RdfXmlTest.php
@@ -52,19 +52,19 @@ class RdfXmlTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         RdfNamespace::resetNamespaces();
         RdfNamespace::reset();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new RdfXml();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::resetNamespaces();
         RdfNamespace::reset();
@@ -269,7 +269,7 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<foaf:name xml:lang="en">Joe</foaf:name>',
             $xml
         );
@@ -284,7 +284,7 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<foaf:age rdf:datatype=\"http://www.w3.org/2001/XMLSchema#int\">59</foaf:age>",
             $xml
         );
@@ -299,8 +299,8 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains("<ns0:foo>bar</ns0:foo>", $xml);
-        $this->assertContains("xmlns:ns0=\"http://www.example.com/ns/\"", $xml);
+        $this->assertStringContainsString("<ns0:foo>bar</ns0:foo>", $xml);
+        $this->assertStringContainsString("xmlns:ns0=\"http://www.example.com/ns/\"", $xml);
     }
 
     public function testSerialiseRdfXmlWithUnshortenableProperty()
@@ -327,7 +327,7 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<foaf:bio rdf:parseType=\"Literal\"><b>html</b></foaf:bio>",
             $xml
         );

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -51,13 +51,13 @@ class TurtleTest extends TestCase
     /** @var Graph */
     protected $graph = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->serialiser = new Turtle();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         RdfNamespace::reset();
         RdfNamespace::resetNamespaces();
@@ -681,7 +681,7 @@ class TurtleTest extends TestCase
         $joe->set('http://example.com/ns/prop', 'bar');
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
-        $this->assertContains(
+        $this->assertStringContainsString(
             "@prefix ns0: <http://example.com/ns/> .",
             $turtle
         );

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -60,7 +60,7 @@ class SerialiserTest extends TestCase
     /**
      * Set up the test suite before each test
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->graph = new Graph();
         $this->resource = $this->graph->resource('http://www.example.com/');

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -53,7 +53,7 @@ class ClientTest extends TestCase
     /** @var  Client */
     private $sparql;
 
-    public function setUp()
+    public function setUp(): void
     {
         Http::setDefaultHttpClient(
             $this->client = new MockClient()

--- a/test/EasyRdf/Sparql/ResultTest.php
+++ b/test/EasyRdf/Sparql/ResultTest.php
@@ -389,15 +389,15 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains("<table class='sparql-results'", $html);
-        $this->assertContains(">?s</th>", $html);
-        $this->assertContains(">?p</th>", $html);
-        $this->assertContains(">?o</th></tr>", $html);
+        $this->assertStringContainsString("<table class='sparql-results'", $html);
+        $this->assertStringContainsString(">?s</th>", $html);
+        $this->assertStringContainsString(">?p</th>", $html);
+        $this->assertStringContainsString(">?o</th></tr>", $html);
 
-        $this->assertContains(">http://www.example.com/joe#me</a></td>", $html);
-        $this->assertContains(">foaf:name</a></td>", $html);
-        $this->assertContains(">&quot;Joe Bloggs&quot;@en</span></td>", $html);
-        $this->assertContains("</table>", $html);
+        $this->assertStringContainsString(">http://www.example.com/joe#me</a></td>", $html);
+        $this->assertStringContainsString(">foaf:name</a></td>", $html);
+        $this->assertStringContainsString(">&quot;Joe Bloggs&quot;@en</span></td>", $html);
+        $this->assertStringContainsString("</table>", $html);
     }
 
     public function testDumpSelectAllText()
@@ -408,15 +408,15 @@ class ResultTest extends TestCase
         );
 
         $text = $result->dump('text');
-        $this->assertContains('+-------------------------------------+', $text);
-        $this->assertContains('| ?s                                  |', $text);
-        $this->assertContains('| http://www.example.com/joe#me       |', $text);
-        $this->assertContains('+---------------------+', $text);
-        $this->assertContains('| ?p                  |', $text);
-        $this->assertContains('| foaf:name           |', $text);
-        $this->assertContains('+--------------------------------+', $text);
-        $this->assertContains('| ?o                             |', $text);
-        $this->assertContains('| "Joe Bloggs"@en                |', $text);
+        $this->assertStringContainsString('+-------------------------------------+', $text);
+        $this->assertStringContainsString('| ?s                                  |', $text);
+        $this->assertStringContainsString('| http://www.example.com/joe#me       |', $text);
+        $this->assertStringContainsString('+---------------------+', $text);
+        $this->assertStringContainsString('| ?p                  |', $text);
+        $this->assertStringContainsString('| foaf:name           |', $text);
+        $this->assertStringContainsString('+--------------------------------+', $text);
+        $this->assertStringContainsString('| ?o                             |', $text);
+        $this->assertStringContainsString('| "Joe Bloggs"@en                |', $text);
     }
 
     public function testDumpSelectUnbound()
@@ -427,13 +427,13 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains(">?person</th>", $html);
-        $this->assertContains(">?name</th>", $html);
-        $this->assertContains(">?foo</th>", $html);
+        $this->assertStringContainsString(">?person</th>", $html);
+        $this->assertStringContainsString(">?name</th>", $html);
+        $this->assertStringContainsString(">?foo</th>", $html);
 
-        $this->assertContains('>http://dbpedia.org/resource/Tim_Berners-Lee</a>', $html);
-        $this->assertContains('>&quot;Tim Berners-Lee&quot;@en</span>', $html);
-        $this->assertContains('<td>&nbsp;</td>', $html);
+        $this->assertStringContainsString('>http://dbpedia.org/resource/Tim_Berners-Lee</a>', $html);
+        $this->assertStringContainsString('>&quot;Tim Berners-Lee&quot;@en</span>', $html);
+        $this->assertStringContainsString('<td>&nbsp;</td>', $html);
     }
 
     public function testDumpAskFalseHtml()
@@ -444,7 +444,7 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains(">false</span>", $html);
+        $this->assertStringContainsString(">false</span>", $html);
     }
 
     public function testDumpAskFalseText()
@@ -510,8 +510,8 @@ class ResultTest extends TestCase
         );
 
         $string = strval($result);
-        $this->assertContains('+-------------------------------------+', $string);
-        $this->assertContains('| http://www.example.com/joe#me       |', $string);
+        $this->assertStringContainsString('+-------------------------------------+', $string);
+        $this->assertStringContainsString('| http://www.example.com/joe#me       |', $string);
     }
 
     public function testUnsupportedFormat()

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -41,7 +41,7 @@ if (!class_exists('\PHPUnit\Framework\Error\Error', true)) {
     class_alias('PHPUnit_Framework_Error', '\PHPUnit\Framework\Error\Error');
 }
 
-class TestCase extends \PHPUnit\Framework\TestCase
+class TestCase extends \Yoast\PHPUnitPolyfills\TestCases\TestCase
 {
 
     public static function assertStringEquals($str1, $str2, $message = null)

--- a/test/EasyRdf/TypeMapperTest.php
+++ b/test/EasyRdf/TypeMapperTest.php
@@ -49,12 +49,12 @@ class MyTypeClass extends Resource
 
 class TypeMapperTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         TypeMapper::set('rdf:mytype', 'EasyRdf\MyTypeClass');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         TypeMapper::delete('rdf:mytype');
         TypeMapper::delete('foaf:Person');


### PR DESCRIPTION
* Uses PHPUnit 8 where supported
* Uses a polyfill to add a forward compatibility layer so code can be the same for PHPUnit 7 and PHPUnit 8 (and this will help with going to PHPUnit 9)
* Since PHP 7.1 is the minimum version added return typehints to setUp etc to get around that issue.