### PR TITLE
Leveraging TypeMapper for internal Lists

### DIFF
--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -183,7 +183,7 @@ class Graph
             isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#first']) or
             isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'])
         ) {
-            return 'EasyRdf\Collection';
+            return TypeMapper::get('rdf:List');
         }
         return TypeMapper::getDefaultResourceClass();
     }


### PR DESCRIPTION
Resolution to EasyRdf\Collection is actually hard-coded, but TypeMapper already has a default mapping for rdf:List which may be overridden by the integrator.