### PR TITLE
Issue #390: Add return types to be compatible with php 8.1.

### DIFF
--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -73,7 +73,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
-    public function seek($position)
+    public function seek($position): void
     {
         if (is_int($position) and $position > 0) {
             list($node, $actual) = $this->getCollectionNode($position);
@@ -95,7 +95,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
     /** Rewind the iterator back to the start of the collection
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 1;
         $this->current = null;
@@ -105,7 +105,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return mixed The current item
      */
-    public function current()
+    public function current(): mixed
     {
         if ($this->position === 1) {
             return $this->get('rdf:first');
@@ -120,7 +120,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return int The current position
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }
@@ -128,7 +128,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
     /** Move forward to next item in the collection
      *
      */
-    public function next()
+    public function next(): void
     {
         if ($this->position === 1) {
             $this->current = $this->get('rdf:rest');
@@ -142,7 +142,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return bool True if the current position is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         if ($this->position === 1 and $this->hasProperty('rdf:first')) {
             return true;
@@ -185,7 +185,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return integer The number of items in the collection
      */
-    public function count()
+    public function count(): int
     {
         // Find the end of the collection
         list($node, $position) = $this->getCollectionNode(null);
@@ -225,7 +225,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * Example: isset($list[2])
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         if (is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
@@ -241,7 +241,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * Example: $item = $list[2];
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
@@ -260,7 +260,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * Example: $list[2] = $item;
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             // No offset - append to end of collection
@@ -291,11 +291,11 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
     }
 
     /**
-     * Array Access: delete an item at a specific postion using array syntax
+     * Array Access: delete an item at a specific position using array syntax
      *
      * Example: unset($seq[2]);
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);

--- a/lib/Container.php
+++ b/lib/Container.php
@@ -70,7 +70,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
-    public function seek($position)
+    public function seek($position): void
     {
         if (is_int($position) and $position > 0) {
             if ($this->hasProperty('rdf:_'.$position)) {
@@ -90,7 +90,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
     /** Rewind the iterator back to the start of the container (item 1)
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 1;
     }
@@ -99,7 +99,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return mixed The current item
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->get('rdf:_'.$this->position);
     }
@@ -108,7 +108,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return int The current position
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }
@@ -116,7 +116,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
     /** Move forward to next item in the container
      *
      */
-    public function next()
+    public function next(): void
     {
         $this->position++;
     }
@@ -125,7 +125,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return bool True if the current position is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->hasProperty('rdf:_'.$this->position);
     }
@@ -137,7 +137,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return integer The number of items in the container
      */
-    public function count()
+    public function count(): int
     {
         $pos = 1;
         while ($this->hasProperty('rdf:_'.$pos)) {
@@ -168,7 +168,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Example: isset($seq[2])
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         if (is_int($offset) and $offset > 0) {
             return $this->hasProperty('rdf:_'.$offset);
@@ -183,7 +183,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Example: $item = $seq[2];
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (is_int($offset) and $offset > 0) {
             return $this->get('rdf:_'.$offset);
@@ -201,7 +201,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Warning: creating gaps in the sequence will result in unexpected behavior
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_int($offset) and $offset > 0) {
             return $this->set('rdf:_'.$offset, $value);
@@ -221,7 +221,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Warning: creating gaps in the sequence will result in unexpected behavior
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (is_int($offset) and $offset > 0) {
             return $this->delete('rdf:_'.$offset);

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -769,7 +769,7 @@ class Resource implements \ArrayAccess
      *
      * @return boolean true on success or false on failure.
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->__isset($offset);
     }
@@ -786,7 +786,7 @@ class Resource implements \ArrayAccess
      *
      * @return mixed Can return all value types.
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->__get($offset);
     }
@@ -804,7 +804,7 @@ class Resource implements \ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->__set($offset, $value);
     }
@@ -821,7 +821,7 @@ class Resource implements \ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->__unset($offset);
     }


### PR DESCRIPTION
I also noticed that some of the method don't have return statements for every case:
Container.php

1. current
2. offsetGet

If you want we can handle it in the separate ticket