### PR TITLE
PHP 8.1 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       dist: bionic
     - php: 8.0
       dist: bionic
+    - php: 8.1
+      dist: bionic
 
 sudo: required
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - php: 8.0
       dist: bionic
     - php: 8.1
-      dist: bionic
+      dist: jammy
 
 sudo: required
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ PHPUNIT = vendor/bin/phpunit
 PHPUNIT_FLAGS = -c config/phpunit.xml
 PHPCS = vendor/bin/phpcs
 PHPCS_FLAGS = --standard=./config/phpcs_ruleset.xml --encoding=utf8 --extensions=php
+PHPSTAN = vendor/bin/phpstan
+PHPSTAN_FLAGS = analyze -l 3
 DOCTUM = vendor/bin/doctum.php
 
 # Composer doesn't work with bsdtar - try and use GNU tar
@@ -122,6 +124,10 @@ clean:
 check-fixme:
 	@git grep -n -E 'FIXME|TODO' || echo "No FIXME or TODO lines found."
 
+.PHONY: phpstan
+phpstan:
+	$(PHP) $(PHP_FLAGS) $(PHPSTAN) $(PHPSTAN_FLAGS) lib
+
 # TARGET:help                You're looking at it!
 .PHONY: help
 help:
@@ -150,3 +156,4 @@ vendor/autoload.php: composer-install
 vendor/bin/phpunit: composer-install
 vendor/bin/phpcs: composer-install
 vendor/bin/doctum.php: composer-install
+vendor/bin/phpstan: composer-install

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "semsol/arc2": "^2.4",
         "squizlabs/php_codesniffer": "3.*",
         "zendframework/zend-http": "~2.3",
-        "yoast/phpunit-polyfills": "^1.0"
+        "yoast/phpunit-polyfills": "^1.0",
+        "phpstan/phpstan": "^1.8"
     },
     "autoload": {
         "psr-4": {

--- a/examples/basic_sparql.php
+++ b/examples/basic_sparql.php
@@ -41,7 +41,7 @@
         'SELECT * WHERE {'.
         '  ?country rdf:type dbo:Country .'.
         '  ?country rdfs:label ?label .'.
-        '  ?country dct:subject dbc:Member_states_of_the_United_Nations .'.
+        '  ?country dct:subject dbc:Current_member_states_of_the_United_Nations .'.
         '  FILTER ( lang(?label) = "en" )'.
         '} ORDER BY ?label'
     );

--- a/examples/converter.php
+++ b/examples/converter.php
@@ -32,7 +32,7 @@
     }
 
     // Stupid PHP :(
-    if (get_magic_quotes_gpc() and isset($_REQUEST['data'])) {
+    if (function_exists('get_magic_quotes_gpc') and get_magic_quotes_gpc() and isset($_REQUEST['data'])) {
         $_REQUEST['data'] = stripslashes($_REQUEST['data']);
     }
 

--- a/examples/html_tag_helpers.php
+++ b/examples/html_tag_helpers.php
@@ -65,7 +65,7 @@ function tag($name, $options = array(), $open = false)
 function content_tag($name, $content = null, $options = array())
 {
     return "<$name".tag_options($options).">".
-           htmlspecialchars($content)."</$name>";
+           htmlspecialchars((string) $content)."</$name>";
 }
 
 function link_to($text, $uri = null, $options = array())

--- a/examples/serialise.php
+++ b/examples/serialise.php
@@ -59,7 +59,7 @@
     if (!is_scalar($data)) {
         $data = var_export($data, true);
     }
-    print htmlspecialchars($data);
+    print htmlspecialchars($data, ENT_COMPAT);
 ?>
 </pre>
 

--- a/examples/sparql_queryform.php
+++ b/examples/sparql_queryform.php
@@ -21,7 +21,7 @@
     require_once __DIR__."/html_tag_helpers.php";
 
     // Stupid PHP :(
-    if (get_magic_quotes_gpc() and isset($_REQUEST['query'])) {
+    if (function_exists('get_magic_quotes_gpc') and get_magic_quotes_gpc() and isset($_REQUEST['query'])) {
         $_REQUEST['query'] = stripslashes($_REQUEST['query']);
     }
 ?>

--- a/examples/uk_postcode.php
+++ b/examples/uk_postcode.php
@@ -60,7 +60,6 @@
             print "<tr><th>Easting:</th><td>" . $res->get('sr:easting') . "</td></tr>\n";
             print "<tr><th>Northing:</th><td>" . $res->get('sr:northing') . "</td></tr>\n";
             print "<tr><th>District:</th><td>" . $res->get('postcode:district')->label() . "</td></tr>\n";
-            print "<tr><th>Ward:</th><td>" . $res->get('postcode:ward')->label() . "</td></tr>\n";
             print "</table>\n";
 
             print "<div style='clear: both'></div>\n";

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -73,7 +73,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
-    public function seek($position)
+    public function seek($position): void
     {
         if (is_int($position) and $position > 0) {
             list($node, $actual) = $this->getCollectionNode($position);
@@ -95,7 +95,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
     /** Rewind the iterator back to the start of the collection
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 1;
         $this->current = null;
@@ -105,13 +105,20 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return mixed The current item
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->position === 1) {
             return $this->get('rdf:first');
         } elseif ($this->current) {
             return $this->current->get('rdf:first');
+        } else {
+            // to match tests but it's worht noting false would be more 
+            // idiomatic according to
+            // https://www.php.net/manual/en/function.current.php
+            return null;
         }
+
     }
 
     /** Return the key / current position in the collection
@@ -120,7 +127,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return int The current position
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -128,7 +135,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
     /** Move forward to next item in the collection
      *
      */
-    public function next()
+    public function next(): void
     {
         if ($this->position === 1) {
             $this->current = $this->get('rdf:rest');
@@ -142,7 +149,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return bool True if the current position is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         if ($this->position === 1 and $this->hasProperty('rdf:first')) {
             return true;
@@ -185,7 +192,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * @return integer The number of items in the collection
      */
-    public function count()
+    public function count(): int
     {
         // Find the end of the collection
         list($node, $position) = $this->getCollectionNode(null);
@@ -225,7 +232,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * Example: isset($list[2])
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         if (is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
@@ -240,13 +247,18 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
     /** Array Access: get an item at a specified position in collection using array syntax
      *
      * Example: $item = $list[2];
+     *
+     * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
             if ($node and $position === $offset) {
                 return $node->get('rdf:first');
+            } else {
+                return null;
             }
         } else {
             throw new \InvalidArgumentException(
@@ -260,7 +272,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * Example: $list[2] = $item;
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             // No offset - append to end of collection
@@ -282,7 +294,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
                 $node->addResource('rdf:rest', 'rdf:nil');
             }
 
-            return $node->set('rdf:first', $value);
+            $node->set('rdf:first', $value);
         } else {
             throw new \InvalidArgumentException(
                 "Collection offset must be a positive integer"
@@ -295,7 +307,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * Example: unset($seq[2]);
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -113,12 +113,11 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
         } elseif ($this->current) {
             return $this->current->get('rdf:first');
         } else {
-            // to match tests but it's worht noting false would be more 
+            // to match tests but it's worht noting false would be more
             // idiomatic according to
             // https://www.php.net/manual/en/function.current.php
             return null;
         }
-
     }
 
     /** Return the key / current position in the collection

--- a/lib/Container.php
+++ b/lib/Container.php
@@ -70,7 +70,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
-    public function seek($position)
+    public function seek($position): void
     {
         if (is_int($position) and $position > 0) {
             if ($this->hasProperty('rdf:_'.$position)) {
@@ -90,7 +90,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
     /** Rewind the iterator back to the start of the container (item 1)
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 1;
     }
@@ -99,6 +99,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return mixed The current item
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->get('rdf:_'.$this->position);
@@ -108,7 +109,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return int The current position
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -116,7 +117,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
     /** Move forward to next item in the container
      *
      */
-    public function next()
+    public function next(): void
     {
         $this->position++;
     }
@@ -125,7 +126,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return bool True if the current position is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->hasProperty('rdf:_'.$this->position);
     }
@@ -137,7 +138,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * @return integer The number of items in the container
      */
-    public function count()
+    public function count(): int
     {
         $pos = 1;
         while ($this->hasProperty('rdf:_'.$pos)) {
@@ -168,7 +169,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Example: isset($seq[2])
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         if (is_int($offset) and $offset > 0) {
             return $this->hasProperty('rdf:_'.$offset);
@@ -182,7 +183,10 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
     /** Array Access: get an item at a specified position in container using array syntax
      *
      * Example: $item = $seq[2];
+     *
+     * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (is_int($offset) and $offset > 0) {
@@ -201,12 +205,12 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Warning: creating gaps in the sequence will result in unexpected behavior
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_int($offset) and $offset > 0) {
-            return $this->set('rdf:_'.$offset, $value);
+            $this->set('rdf:_'.$offset, $value);
         } elseif (is_null($offset)) {
-            return $this->append($value);
+            $this->append($value);
         } else {
             throw new \InvalidArgumentException(
                 "Container position must be a positive integer"
@@ -221,10 +225,10 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * Warning: creating gaps in the sequence will result in unexpected behavior
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (is_int($offset) and $offset > 0) {
-            return $this->delete('rdf:_'.$offset);
+            $this->delete('rdf:_'.$offset);
         } else {
             throw new \InvalidArgumentException(
                 "Container position must be a positive integer"

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -248,7 +248,7 @@ class Format
      * @param string  $data     The document data
      * @param string  $filename Optional filename
      *
-     * @return self  New format object
+     * @return self|null  New format object
      */
     public static function guessFormat($data, $filename = null)
     {
@@ -267,7 +267,7 @@ class Format
         }
 
         // Then try and guess by the first 1024 bytes of content
-        $short = substr($data, 0, 1024);
+        $short = substr((string) $data, 0, 1024);
         if (preg_match('/^\s*\{/', $short)) {
             return self::getFormat('json');
         } elseif (preg_match('/<rdf:/i', $short)) {
@@ -375,13 +375,15 @@ class Format
 
     /** Get the default registered mime type for a format object
      *
-     * @return string The default mime type as a string.
+     * @return string|null The default mime type as a string.
      */
     public function getDefaultMimeType()
     {
         $types = array_keys($this->mimeTypes);
         if (isset($types[0])) {
             return $types[0];
+        } else {
+            return null;
         }
     }
 
@@ -413,12 +415,14 @@ class Format
 
     /** Get the default registered file extension (filename suffix) for a format object
      *
-     * @return string The default extension as a string.
+     * @return string|null The default extension as a string.
      */
     public function getDefaultExtension()
     {
         if (isset($this->extensions[0])) {
             return $this->extensions[0];
+        } else {
+            return null;
         }
     }
 

--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -1465,7 +1465,7 @@ class Graph
      *
      * @param string|null $resource
      *
-     * @return string A type assocated with the resource (e.g. foaf:Document)
+     * @return string|null A type assocated with the resource (e.g. foaf:Document)
      */
     public function type($resource = null)
     {
@@ -1486,7 +1486,7 @@ class Graph
      *
      * @param mixed $resource
      *
-     * @return \EasyRdf\Resource  A type associated with the resource
+     * @return \EasyRdf\Resource|null  A type associated with the resource
      */
     public function typeAsResource($resource = null)
     {
@@ -1634,7 +1634,7 @@ class Graph
      *
      * @param mixed $resource
      *
-     * @return \EasyRdf\Resource  The primary topic of the document.
+     * @return \EasyRdf\Resource|null  The primary topic of the document.
      */
     public function primaryTopic($resource = null)
     {
@@ -1745,11 +1745,9 @@ class Graph
      *
      * @see RdfNamespace::setDefault()
      * @param string $name The name of the property
-     *
-     * @return integer
      */
-    public function __unset($name)
+    public function __unset($name): void
     {
-        return $this->delete($this->uri, $name);
+        $this->delete($this->uri, $name);
     }
 }

--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -95,7 +95,7 @@ class Client
      *
      * @var string
      */
-    private $rawPostData = null;
+    private $rawPostData;
 
     /**
      * Redirection counter
@@ -281,7 +281,7 @@ class Client
      *
      * @param string $name
      *
-     * @return string value
+     * @return string|null value
      */
     public function getParameterGet($name)
     {
@@ -335,11 +335,11 @@ class Client
     /**
      * Get the raw (already encoded) POST data.
      *
-     * @return string
+     * @return string|null
      */
     public function getRawData()
     {
-        return $this->rawPostData;
+        return isset($this->rawPostData) ? $this->rawPostData : null;
     }
 
     /**
@@ -359,7 +359,7 @@ class Client
     {
         // Reset parameter data
         $this->paramsGet   = array();
-        $this->rawPostData = null;
+        unset($this->rawPostData);
         $this->method      = 'GET';
 
         if ($clearAll) {

--- a/lib/Http/Response.php
+++ b/lib/Http/Response.php
@@ -81,6 +81,13 @@ class Response
     private $body;
 
     /**
+     * The HTTP Version (1.0 or 1.1)
+     *
+     * @var string
+     */
+    private $version;
+
+    /**
      * Constructor.
      *
      * @param  int     $status HTTP Status code
@@ -167,11 +174,11 @@ class Response
     {
         $body = $this->body;
 
-        if ('chunked' === strtolower($this->getHeader('transfer-encoding'))) {
+        if ('chunked' === strtolower((string) $this->getHeader('transfer-encoding'))) {
             $body = self::decodeChunkedBody($body);
         }
 
-        $contentEncoding = strtolower($this->getHeader('content-encoding'));
+        $contentEncoding = strtolower((string) $this->getHeader('content-encoding'));
 
         if ('gzip' === $contentEncoding) {
             $body = self::decodeGzip($body);

--- a/lib/Literal.php
+++ b/lib/Literal.php
@@ -179,7 +179,7 @@ class Literal
      *
      * @param mixed $value
      *
-     * @return string  A URI for the datatype of $value.
+     * @return string|null  A URI for the datatype of $value.
      */
     public static function getDatatypeForValue($value)
     {
@@ -243,7 +243,7 @@ class Literal
 
     /** Returns the value of the literal.
      *
-     * @return string  Value of this literal.
+     * @return mixed  Value of this literal.
      */
     public function getValue()
     {
@@ -261,7 +261,7 @@ class Literal
 
     /** Returns the shortened datatype URI of the literal.
      *
-     * @return string  Datatype of this literal (e.g. xsd:integer).
+     * @return string|null  Datatype of this literal (e.g. xsd:integer).
      */
     public function getDatatype()
     {

--- a/lib/Literal/Date.php
+++ b/lib/Literal/Date.php
@@ -92,7 +92,7 @@ class Date extends Literal
     /** Returns the date as a PHP DateTime object
      *
      * @see DateTime::format
-     * @return string
+     * @return \DateTime
      */
     public function getValue()
     {

--- a/lib/Parser/Arc.php
+++ b/lib/Parser/Arc.php
@@ -43,7 +43,7 @@ namespace EasyRdf\Parser;
  * @copyright  Copyright (c) Nicholas J Humfrey
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
-class Arc extends RdfPhp
+class Arc extends \EasyRdf\Parser
 {
     private static $supportedTypes = array(
         'rdfxml' => 'RDFXML',
@@ -65,7 +65,7 @@ class Arc extends RdfPhp
     /**
      * Parse an RDF document into an EasyRdf\Graph
      *
-     * @param Graph  $graph   the graph to load the data into
+     * @param \EasyRdf\Graph  $graph   the graph to load the data into
      * @param string $data    the RDF document data
      * @param string $format  the format of the input data
      * @param string $baseUri the base URI of the data being parsed
@@ -89,7 +89,7 @@ class Arc extends RdfPhp
         if ($parser) {
             $parser->parse($baseUri, $data);
             $rdfphp = $parser->getSimpleIndex(false);
-            return parent::parse($graph, $rdfphp, 'php', $baseUri);
+            return (new RdfPhp())->parse($graph, $rdfphp, 'php', $baseUri);
         } else {
             throw new \EasyRdf\Exception(
                 "ARC2 failed to get a $className parser."

--- a/lib/Parser/Json.php
+++ b/lib/Parser/Json.php
@@ -36,6 +36,7 @@ namespace EasyRdf\Parser;
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
 use EasyRdf\Graph;
+use EasyRdf\Parser;
 
 /**
  * A pure-php class to parse RDF/JSON with no dependencies.
@@ -46,7 +47,7 @@ use EasyRdf\Graph;
  * @copyright  Copyright (c) Nicholas J Humfrey
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
-class Json extends RdfPhp
+class Json extends Parser
 {
     private $jsonLastErrorExists = false;
 
@@ -152,7 +153,7 @@ class Json extends RdfPhp
         if (array_key_exists('triples', $decoded)) {
             return $this->parseJsonTriples($decoded, $baseUri);
         } else {
-            return parent::parse($graph, $decoded, 'php', $baseUri);
+            return (new RdfPhp)->parse($graph, $decoded, 'php', $baseUri);
         }
     }
 }

--- a/lib/Parser/RdfXml.php
+++ b/lib/Parser/RdfXml.php
@@ -50,6 +50,10 @@ use EasyRdf\Parser;
  */
 class RdfXml extends Parser
 {
+    /**
+     * @var \XMLParser
+     */
+    private $xmlParser;
     private $state;
     private $xLang;
     private $xBase;

--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -146,7 +146,7 @@ class RdfNamespace
       * @param string $prefix The namespace prefix (eg 'foaf')
       *
       * @throws \InvalidArgumentException
-      * @return string The namespace URI (eg 'http://xmlns.com/foaf/0.1/')
+      * @return string|null The namespace URI (eg 'http://xmlns.com/foaf/0.1/')
       */
     public static function get($prefix)
     {
@@ -326,7 +326,7 @@ class RdfNamespace
       * @param bool    $createNamespace If true, a new namespace will be created
       *
       * @throws \InvalidArgumentException
-      * @return array  The split URI (eg 'foaf', 'name') or null
+      * @return array|null  The split URI (eg 'foaf', 'name') or null
       */
     public static function splitUri($uri, $createNamespace = false)
     {
@@ -376,13 +376,15 @@ class RdfNamespace
       * Return the prefix namespace that a URI belongs to.
       *
       * @param string $uri A full URI (eg 'http://xmlns.com/foaf/0.1/name')
-     *
-      * @return string The prefix namespace that it is a part of(eg 'foaf')
+      *
+      * @return string|null The prefix namespace that it is a part of(eg 'foaf') or null
       */
     public static function prefixOfUri($uri)
     {
         if ($parts = self::splitUri($uri)) {
             return $parts[0];
+        } else {
+            return null;
         }
     }
 
@@ -398,12 +400,14 @@ class RdfNamespace
       * @param string  $uri The full URI (eg 'http://xmlns.com/foaf/0.1/name')
       * @param bool    $createNamespace If true, a new namespace will be created
       *
-      * @return string The shortened URI (eg 'foaf:name') or null
+      * @return string|null The shortened URI (eg 'foaf:name') or null
       */
     public static function shorten($uri, $createNamespace = false)
     {
         if ($parts = self::splitUri($uri, $createNamespace)) {
             return implode(':', $parts);
+        } else {
+            return null;
         }
     }
 

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -116,7 +116,7 @@ class Resource implements \ArrayAccess
      *
      * Returns null if the resource is not a blank node.
      *
-     * @return string The identifer for the bnode
+     * @return string|null The identifer for the bnode
      */
     public function getBNodeId()
     {
@@ -156,12 +156,14 @@ class Resource implements \ArrayAccess
      * The local name is defined as the part of the URI string
      * after the last occurrence of the '#', ':' or '/' character.
      *
-     * @return string The local name
+     * @return string|null The local name
      */
     public function localName()
     {
         if (preg_match("|([^#:/]+)$|", $this->uri, $matches)) {
             return $matches[1];
+        } else {
+            return null;
         }
     }
 
@@ -747,12 +749,10 @@ class Resource implements \ArrayAccess
      * @see EasyRdf\RdfNamespace::setDefault()
      *
      * @param string $name The name of the property
-     *
-     * @return int
      */
-    public function __unset($name)
+    public function __unset($name): void
     {
-        return $this->graph->delete($this->uri, $name);
+        $this->graph->delete($this->uri, $name);
     }
 
     /**
@@ -769,7 +769,7 @@ class Resource implements \ArrayAccess
      *
      * @return boolean true on success or false on failure.
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->__isset($offset);
     }
@@ -786,6 +786,7 @@ class Resource implements \ArrayAccess
      *
      * @return mixed Can return all value types.
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->__get($offset);
@@ -804,7 +805,7 @@ class Resource implements \ArrayAccess
      *
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->__set($offset, $value);
     }
@@ -821,7 +822,7 @@ class Resource implements \ArrayAccess
      *
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->__unset($offset);
     }

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -102,7 +102,8 @@ abstract class Serialiser
      * @param Format|string $format The name of the format to convert to.
      * @param array         $options
      *
-     * @return string|array The RDF in the new desired format (RdfPhp format returns an array, other serialisers return a string).
+     * @return string|array The RDF in the new desired format
+     *   (RdfPhp format returns an array, other serialisers return a string).
      */
     abstract public function serialise(Graph $graph, $format, array $options = array());
 }

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -102,7 +102,7 @@ abstract class Serialiser
      * @param Format|string $format The name of the format to convert to.
      * @param array         $options
      *
-     * @return string The RDF in the new desired format.
+     * @return string|array The RDF in the new desired format (RdfPhp format returns an array, other serialisers return a string).
      */
     abstract public function serialise(Graph $graph, $format, array $options = array());
 }

--- a/lib/Serialiser/Arc.php
+++ b/lib/Serialiser/Arc.php
@@ -38,6 +38,7 @@ namespace EasyRdf\Serialiser;
 use EasyRdf\Exception;
 use EasyRdf\Format;
 use EasyRdf\Graph;
+use EasyRdf\Serialiser;
 
 /**
  * Class to serialise RDF using the ARC2 library.
@@ -46,7 +47,7 @@ use EasyRdf\Graph;
  * @copyright  Copyright (c) Nicholas J Humfrey
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
-class Arc extends RdfPhp
+class Arc extends Serialiser
 {
     private static $supportedTypes = array(
         'rdfxml' => 'RDFXML',
@@ -92,7 +93,7 @@ class Arc extends RdfPhp
         $serialiser = \ARC2::getSer($className);
         if ($serialiser) {
             return $serialiser->getSerializedIndex(
-                parent::serialise($graph, 'php')
+                (new RdfPhp())->serialise($graph, 'php')
             );
         } else {
             throw new Exception(

--- a/lib/Serialiser/Json.php
+++ b/lib/Serialiser/Json.php
@@ -37,6 +37,7 @@ namespace EasyRdf\Serialiser;
  */
 use EasyRdf\Exception;
 use EasyRdf\Graph;
+use EasyRdf\Serialiser;
 
 /**
  * Class to serialise an EasyRdf\Graph to RDF/JSON
@@ -46,7 +47,7 @@ use EasyRdf\Graph;
  * @copyright  Copyright (c) Nicholas J Humfrey
  * @license    https://www.opensource.org/licenses/bsd-license.php
  */
-class Json extends RdfPhp
+class Json extends Serialiser
 {
     /**
      * Serialise an EasyRdf\Graph into a to RDF/JSON document.
@@ -70,6 +71,6 @@ class Json extends RdfPhp
             );
         }
 
-        return json_encode(parent::serialise($graph, 'php'));
+        return json_encode((new RdfPhp())->serialise($graph, 'php'));
     }
 }

--- a/lib/Serialiser/RdfPhp.php
+++ b/lib/Serialiser/RdfPhp.php
@@ -58,7 +58,7 @@ class RdfPhp extends Serialiser
      * @param string $format The name of the format to convert to.
      * @param array  $options
      *
-     * @return string The RDF in the new desired format.
+     * @return array The RDF in the new desired format.
      * @throws Exception
      */
     public function serialise(Graph $graph, $format, array $options = array())

--- a/lib/Serialiser/RdfXml.php
+++ b/lib/Serialiser/RdfXml.php
@@ -78,11 +78,11 @@ class RdfXml extends Serialiser
             $tag = "{$indent}<{$property}";
             if ($obj->isBNode()) {
                 if ($alreadyOutput or $rpcount > 1 or $pcount == 0) {
-                    $tag .= " rdf:nodeID=\"".htmlspecialchars($obj->getBNodeId()).'"';
+                    $tag .= " rdf:nodeID=\"".htmlspecialchars($obj->getBNodeId(), ENT_COMPAT).'"';
                 }
             } else {
                 if ($alreadyOutput or $rpcount != 1 or $pcount == 0) {
-                    $tag .= " rdf:resource=\"".htmlspecialchars($obj->getURI()).'"';
+                    $tag .= " rdf:resource=\"".htmlspecialchars($obj->getURI(), ENT_COMPAT).'"';
                 }
             }
 
@@ -104,17 +104,17 @@ class RdfXml extends Serialiser
                     $atrributes .= " rdf:parseType=\"Literal\"";
                     $value = strval($obj);
                 } else {
-                    $datatype = htmlspecialchars($datatype);
+                    $datatype = htmlspecialchars($datatype, ENT_COMPAT);
                     $atrributes .= " rdf:datatype=\"$datatype\"";
                 }
             } elseif ($obj->getLang()) {
                 $atrributes .= ' xml:lang="'.
-                               htmlspecialchars($obj->getLang()).'"';
+                               htmlspecialchars($obj->getLang(), ENT_COMPAT).'"';
             }
 
             // Escape the value
             if (!isset($value)) {
-                $value = htmlspecialchars(strval($obj));
+                $value = htmlspecialchars(strval($obj), ENT_COMPAT);
             }
 
             return "{$indent}<{$property}{$atrributes}>{$value}</{$property}>\n";
@@ -155,10 +155,10 @@ class RdfXml extends Serialiser
         $xml = "\n$indent<$type";
         if ($res->isBNode()) {
             if ($showNodeId) {
-                $xml .= ' rdf:nodeID="'.htmlspecialchars($res->getBNodeId()).'"';
+                $xml .= ' rdf:nodeID="'.htmlspecialchars($res->getBNodeId(), ENT_COMPAT).'"';
             }
         } else {
-            $xml .= ' rdf:about="'.htmlspecialchars($res->getUri()).'"';
+            $xml .= ' rdf:about="'.htmlspecialchars($res->getUri(), ENT_COMPAT).'"';
         }
         $xml .= ">\n";
 
@@ -244,9 +244,9 @@ class RdfXml extends Serialiser
             }
 
             if (strlen($prefix) === 0) {
-                $namespaceStr .= ' xmlns="'.htmlspecialchars($url).'"';
+                $namespaceStr .= ' xmlns="'.htmlspecialchars($url, ENT_COMPAT).'"';
             } else {
-                $namespaceStr .= ' xmlns:'.$prefix.'="'.htmlspecialchars($url).'"';
+                $namespaceStr .= ' xmlns:'.$prefix.'="'.htmlspecialchars($url, ENT_COMPAT).'"';
             }
         }
 

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -313,7 +313,7 @@ class Turtle extends Serialiser
     {
         $turtle = '';
         foreach ($graph->resources() as $resource) {
-            /** @var $resource Resource */
+            /** @var Resource $resource */
             // If the resource has no properties - don't serialise it
             $properties = $resource->propertyUris();
             if (count($properties) == 0) {

--- a/lib/Sparql/Client.php
+++ b/lib/Sparql/Client.php
@@ -71,7 +71,7 @@ class Client
     {
         $this->queryUri = $queryUri;
 
-        if (strlen(parse_url($queryUri, PHP_URL_QUERY)) > 0) {
+        if (strlen((string) parse_url($queryUri, PHP_URL_QUERY)) > 0) {
             $this->queryUri_has_params = true;
         } else {
             $this->queryUri_has_params = false;

--- a/lib/TypeMapper.php
+++ b/lib/TypeMapper.php
@@ -58,7 +58,7 @@ class TypeMapper
      * @param  string  $type   The RDF type (e.g. foaf:Person)
      *
      * @throws \InvalidArgumentException
-     * @return string          The class name (e.g. Model_Foaf_Name)
+     * @return string|null          The class name (e.g. Model_Foaf_Name)
      */
     public static function get($type)
     {

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -215,7 +215,7 @@ class Utils
      */
     public static function parseMimeType($mimeType)
     {
-        $parts = explode(';', strtolower($mimeType));
+        $parts = explode(';', strtolower((string) $mimeType));
         $type = trim(array_shift($parts));
         $params = array();
         foreach ($parts as $part) {

--- a/test/EasyRdf/Http/MockClient.php
+++ b/test/EasyRdf/Http/MockClient.php
@@ -63,7 +63,7 @@ class MockClient extends Client
             } else {
                 $uri['query'] = '';
             }
-            $uri['query'] .= http_build_query($params, null, '&');
+            $uri['query'] .= http_build_query($params, '', '&');
         }
 
         # Try and find a matching response

--- a/test/examples/BasicSparqlTest.php
+++ b/test/examples/BasicSparqlTest.php
@@ -43,26 +43,26 @@ class BasicSparqlTest extends \EasyRdf\TestCase
     public function testCountries()
     {
         $output = executeExample('basic_sparql.php');
-        $this->assertContains('<title>EasyRdf Basic Sparql Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf Basic Sparql Example</h1>', $output);
-        $this->assertContains('<h2>List of countries</h2>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Basic Sparql Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Basic Sparql Example</h1>', $output);
+        $this->assertStringContainsString('<h2>List of countries</h2>', $output);
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/China">China</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/India">India</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/United_States">United States</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/United_Kingdom">United Kingdom</a></li>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<li><a href="http://dbpedia.org/resource/Zimbabwe">Zimbabwe</a></li>',
             $output
         );

--- a/test/examples/BasicTest.php
+++ b/test/examples/BasicTest.php
@@ -43,7 +43,7 @@ class BasicTest extends \EasyRdf\TestCase
     public function testPageRendersCorrectly()
     {
         $output = executeExample('basic.php');
-        $this->assertContains('<title>Basic FOAF example</title>', $output);
-        $this->assertContains('My name is: Nicholas J Humfrey', $output);
+        $this->assertStringContainsString('<title>Basic FOAF example</title>', $output);
+        $this->assertStringContainsString('My name is: Nicholas J Humfrey', $output);
     }
 }

--- a/test/examples/ConverterTest.php
+++ b/test/examples/ConverterTest.php
@@ -43,11 +43,11 @@ class ConverterTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('converter.php');
-        $this->assertContains('<title>EasyRdf Converter</title>', $output);
-        $this->assertContains('<h1>EasyRdf Converter</h1>', $output);
-        $this->assertContains('<option value="ntriples">N-Triples</option>', $output);
-        $this->assertContains('<option value="turtle">Turtle Terse RDF Triple Language</option>', $output);
-        $this->assertContains('<option value="rdfxml">RDF/XML</option>', $output);
+        $this->assertStringContainsString('<title>EasyRdf Converter</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Converter</h1>', $output);
+        $this->assertStringContainsString('<option value="ntriples">N-Triples</option>', $output);
+        $this->assertStringContainsString('<option value="turtle">Turtle Terse RDF Triple Language</option>', $output);
+        $this->assertStringContainsString('<option value="rdfxml">RDF/XML</option>', $output);
     }
 
     public function testConvertRdfXmlToNtriples()
@@ -68,9 +68,9 @@ class ConverterTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf Converter</title>', $output);
-        $this->assertContains('<h1>EasyRdf Converter</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Converter</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Converter</h1>', $output);
+        $this->assertStringContainsString(
             '&lt;http://www.w3.org/&gt; '.
             '&lt;http://purl.org/dc/elements/1.1/title&gt; '.
             '&quot;World Wide Web Consortium&quot; .',
@@ -89,25 +89,25 @@ class ConverterTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf Converter</title>', $output);
-        $this->assertContains('<h1>EasyRdf Converter</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Converter</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Converter</h1>', $output);
+        $this->assertStringContainsString(
             '&lt;http://www.w3.org/TR/rdf-syntax-grammar&gt; '.
             '&lt;http://purl.org/dc/elements/1.1/title&gt; '.
             '&quot;RDF/XML Syntax Specification (Revised)&quot; .',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '&lt;http://www.w3.org/TR/rdf-syntax-grammar&gt; '.
             '&lt;http://example.org/stuff/1.0/editor&gt; _:genid1 .',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '_:genid1 &lt;http://example.org/stuff/1.0/fullname&gt; '.
             '&quot;Dave Beckett&quot; .',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '_:genid1 &lt;http://example.org/stuff/1.0/homePage&gt; '.
             '&lt;http://purl.org/net/dajobe/&gt; .',
             $output

--- a/test/examples/DumpTest.php
+++ b/test/examples/DumpTest.php
@@ -43,8 +43,8 @@ class DumpTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('dump.php');
-        $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
-        $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
     }
 
     public function testDumpHTML()
@@ -57,12 +57,12 @@ class DumpTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
-        $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);
-        $this->assertContains('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
-        $this->assertContains("color:blue'>http://example/q?abc=1&amp;def=2</a>", $output);
-        $this->assertContains("color:green'>rdf:value</span>", $output);
-        $this->assertContains("color:black'>&quot;xxx&quot;</span>", $output);
+        $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
+        $this->assertStringContainsString('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
+        $this->assertStringContainsString("color:blue'>http://example/q?abc=1&amp;def=2</a>", $output);
+        $this->assertStringContainsString("color:green'>rdf:value</span>", $output);
+        $this->assertStringContainsString("color:black'>&quot;xxx&quot;</span>", $output);
     }
 
     public function testDumpText()
@@ -74,10 +74,10 @@ class DumpTest extends \EasyRdf\TestCase
                 'format' => 'text'
             )
         );
-        $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
-        $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);
-        $this->assertContains('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
-        $this->assertContains('http://example/q?abc=1&def=2 (EasyRdf\Resource)', $output);
-        $this->assertContains('-> rdf:value -> "xxx"', $output);
+        $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
+        $this->assertStringContainsString('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
+        $this->assertStringContainsString('http://example/q?abc=1&def=2 (EasyRdf\Resource)', $output);
+        $this->assertStringContainsString('-> rdf:value -> "xxx"', $output);
     }
 }

--- a/test/examples/DumpTest.php
+++ b/test/examples/DumpTest.php
@@ -59,8 +59,14 @@ class DumpTest extends \EasyRdf\TestCase
 
         $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
         $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
-        $this->assertStringContainsString('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
-        $this->assertStringContainsString("color:blue'>http://example/q?abc=1&amp;def=2</a>", $output);
+        $this->assertStringContainsString(
+            'Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf',
+            $output
+        );
+        $this->assertStringContainsString(
+            "color:blue'>http://example/q?abc=1&amp;def=2</a>",
+            $output
+        );
         $this->assertStringContainsString("color:green'>rdf:value</span>", $output);
         $this->assertStringContainsString("color:black'>&quot;xxx&quot;</span>", $output);
     }
@@ -76,7 +82,10 @@ class DumpTest extends \EasyRdf\TestCase
         );
         $this->assertStringContainsString('<title>EasyRdf Graph Dumper</title>', $output);
         $this->assertStringContainsString('<h1>EasyRdf Graph Dumper</h1>', $output);
-        $this->assertStringContainsString('Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf', $output);
+        $this->assertStringContainsString(
+            'Graph: http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf',
+            $output
+        );
         $this->assertStringContainsString('http://example/q?abc=1&def=2 (EasyRdf\Resource)', $output);
         $this->assertStringContainsString('-> rdf:value -> "xxx"', $output);
     }

--- a/test/examples/FoafinfoTest.php
+++ b/test/examples/FoafinfoTest.php
@@ -43,9 +43,9 @@ class FoafinfoTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('foafinfo.php');
-        $this->assertContains('<title>EasyRdf FOAF Info Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Info Example</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf FOAF Info Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Info Example</h1>', $output);
+        $this->assertStringContainsString(
             '<input type="text" name="uri" id="uri" value="http://njh.me/foaf.rdf" size="50" />',
             $output
         );
@@ -58,19 +58,19 @@ class FoafinfoTest extends \EasyRdf\TestCase
             array('uri' => 'http://njh.me/foaf.rdf')
         );
 
-        $this->assertContains('<title>EasyRdf FOAF Info Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Info Example</h1>', $output);
-        $this->assertContains("<dt>Name:</dt><dd>Nicholas J Humfrey</dd>", $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf FOAF Info Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Info Example</h1>', $output);
+        $this->assertStringContainsString("<dt>Name:</dt><dd>Nicholas J Humfrey</dd>", $output);
+        $this->assertStringContainsString(
             "<dt>Homepage:</dt><dd><a href=\"http://www.aelius.com/njh/\">http://www.aelius.com/njh/</a></dd>",
             $output
         );
 
-        $this->assertContains("<h2>Known Persons</h2>", $output);
-        $this->assertContains(">Patrick Sinclair</a></li>", $output);
-        $this->assertContains(">Yves Raimond</a></li>", $output);
+        $this->assertStringContainsString("<h2>Known Persons</h2>", $output);
+        $this->assertStringContainsString(">Patrick Sinclair</a></li>", $output);
+        $this->assertStringContainsString(">Yves Raimond</a></li>", $output);
 
-        $this->assertContains("<h2>Interests</h2>", $output);
-        $this->assertContains(">RDF</a></li>", $output);
+        $this->assertStringContainsString("<h2>Interests</h2>", $output);
+        $this->assertStringContainsString(">RDF</a></li>", $output);
     }
 }

--- a/test/examples/FoafmakerTest.php
+++ b/test/examples/FoafmakerTest.php
@@ -43,8 +43,8 @@ class FoafmakerTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('foafmaker.php');
-        $this->assertContains('<title>EasyRdf FOAF Maker Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Maker Example</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf FOAF Maker Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Maker Example</h1>', $output);
     }
 
     public function testJoeBloggs()
@@ -67,9 +67,9 @@ class FoafmakerTest extends \EasyRdf\TestCase
             )
         );
 
-        $this->assertContains('<title>EasyRdf FOAF Maker Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf FOAF Maker Example</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf FOAF Maker Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf FOAF Maker Example</h1>', $output);
+        $this->assertStringContainsString(
             "@prefix foaf: &lt;http://xmlns.com/foaf/0.1/&gt; .\n\n".
             "&lt;http://www.example.com/joe#me&gt;\n".
             "  a foaf:Person ;\n".

--- a/test/examples/GraphdirectTest.php
+++ b/test/examples/GraphdirectTest.php
@@ -43,25 +43,25 @@ class GraphdirectTest extends \EasyRdf\TestCase
     public function test()
     {
         $output = executeExample('graph_direct.php');
-        $this->assertContains('<title>Example of using EasyRdf\\Graph directly</title>', $output);
+        $this->assertStringContainsString('<title>Example of using EasyRdf\\Graph directly</title>', $output);
 
-        $this->assertContains('<b>Name:</b> Joe Bloggs <br />', $output);
-        $this->assertContains('<b>Names:</b> Joe Bloggs Joseph Bloggs <br />', $output);
+        $this->assertStringContainsString('<b>Name:</b> Joe Bloggs <br />', $output);
+        $this->assertStringContainsString('<b>Names:</b> Joe Bloggs Joseph Bloggs <br />', $output);
 
-        $this->assertContains('<b>Label:</b> Nick <br />', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<b>Label:</b> Nick <br />', $output);
+        $this->assertStringContainsString(
             '<b>Properties:</b> rdf:type, foaf:name, rdfs:label <br />',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<b>PropertyUris:</b> http://www.w3.org/1999/02/22-rdf-syntax-ns#type, '.
             'http://xmlns.com/foaf/0.1/name, http://www.w3.org/2000/01/rdf-schema#label <br />',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<b>People:</b> http://example.com/joe, http://njh.me/ <br />',
             $output
         );
-        $this->assertContains('<b>Unknown:</b>  <br />', $output);
+        $this->assertStringContainsString('<b>Unknown:</b>  <br />', $output);
     }
 }

--- a/test/examples/HttpgetTest.php
+++ b/test/examples/HttpgetTest.php
@@ -43,17 +43,17 @@ class HttpgetTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('httpget.php');
-        $this->assertContains('<title>Test EasyRdf HTTP Client Get</title>', $output);
-        $this->assertContains('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>Test EasyRdf HTTP Client Get</title>', $output);
+        $this->assertStringContainsString('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
+        $this->assertStringContainsString(
             '<input type="text" name="uri" id="uri" value="http://tomheath.com/id/me" size="50" />',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="application/rdf+xml">application/rdf+xml</option>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<option value="text/html">text/html</option>',
             $output
         );
@@ -68,10 +68,10 @@ class HttpgetTest extends \EasyRdf\TestCase
                 'accept' => 'text/html'
             )
         );
-        $this->assertContains('<title>Test EasyRdf HTTP Client Get</title>', $output);
-        $this->assertContains('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
-        $this->assertContains('<b>Content-type</b>: text/html', $output);
-        $this->assertContains('&lt;h1&gt;Home - Tom Heath&lt;/h1&gt;', $output);
+        $this->assertStringContainsString('<title>Test EasyRdf HTTP Client Get</title>', $output);
+        $this->assertStringContainsString('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
+        $this->assertStringContainsString('<b>Content-type</b>: text/html', $output);
+        $this->assertStringContainsString('&lt;h1&gt;Home - Tom Heath&lt;/h1&gt;', $output);
     }
 
     public function testRdfXml()
@@ -83,10 +83,10 @@ class HttpgetTest extends \EasyRdf\TestCase
                 'accept' => 'application/rdf+xml'
             )
         );
-        $this->assertContains('<title>Test EasyRdf HTTP Client Get</title>', $output);
-        $this->assertContains('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
-        $this->assertContains('<b>Content-type</b>: application/rdf+xml', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>Test EasyRdf HTTP Client Get</title>', $output);
+        $this->assertStringContainsString('<h1>Test EasyRdf HTTP Client Get</h1>', $output);
+        $this->assertStringContainsString('<b>Content-type</b>: application/rdf+xml', $output);
+        $this->assertStringContainsString(
             '&lt;foaf:Person rdf:about=&quot;http://tomheath.com/id/me&quot;&gt;',
             $output
         );

--- a/test/examples/OpenGraphProtocolTest.php
+++ b/test/examples/OpenGraphProtocolTest.php
@@ -43,10 +43,10 @@ class OpenGraphProtocolTest extends \EasyRdf\TestCase
     public function testRottenTomatoes()
     {
         $output = executeExample('open_graph_protocol.php');
-        $this->assertContains('<dd><a href="https://www.imdb.com/title/tt0240772/"', $output);
-        $this->assertContains('<dt>Site Name:</dt> <dd>IMDb</dd>', $output);
-        $this->assertContains('<dt>Title:</dt> <dd>Ocean\'s Eleven (2001) - IMDb</dd>', $output);
-        $this->assertContains('<dt>Description:</dt> <dd>Ocean\'s Eleven: Directed by Steven Soderbergh', $output);
-        $this->assertContains('src="https://m.media-amazon.com/images/', $output);
+        $this->assertStringContainsString('<dd><a href="https://www.imdb.com/title/tt0240772/"', $output);
+        $this->assertStringContainsString('<dt>Site Name:</dt> <dd>IMDb</dd>', $output);
+        $this->assertStringContainsString('<dt>Title:</dt> <dd>Ocean\'s Eleven (2001) - IMDb</dd>', $output);
+        $this->assertStringContainsString('<dt>Description:</dt> <dd>Ocean\'s Eleven: Directed by Steven Soderbergh', $output);
+        $this->assertStringContainsString('src="https://m.media-amazon.com/images/', $output);
     }
 }

--- a/test/examples/OpenGraphProtocolTest.php
+++ b/test/examples/OpenGraphProtocolTest.php
@@ -46,7 +46,10 @@ class OpenGraphProtocolTest extends \EasyRdf\TestCase
         $this->assertStringContainsString('<dd><a href="https://www.imdb.com/title/tt0240772/"', $output);
         $this->assertStringContainsString('<dt>Site Name:</dt> <dd>IMDb</dd>', $output);
         $this->assertStringContainsString('<dt>Title:</dt> <dd>Ocean\'s Eleven (2001) - IMDb</dd>', $output);
-        $this->assertStringContainsString('<dt>Description:</dt> <dd>Ocean\'s Eleven: Directed by Steven Soderbergh', $output);
+        $this->assertStringContainsString(
+            '<dt>Description:</dt> <dd>Ocean\'s Eleven: Directed by Steven Soderbergh',
+            $output
+        );
         $this->assertStringContainsString('src="https://m.media-amazon.com/images/', $output);
     }
 }

--- a/test/examples/ParseRssTest.php
+++ b/test/examples/ParseRssTest.php
@@ -43,8 +43,8 @@ class ParseRssTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('parse_rss.php');
-        $this->assertContains('<title>EasyRdf RSS 1.0 Parsing example</title>', $output);
-        $this->assertContains('<h1>EasyRdf RSS 1.0 Parsing example</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf RSS 1.0 Parsing example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf RSS 1.0 Parsing example</h1>', $output);
     }
 
     public function testPlanetRdf()
@@ -53,15 +53,15 @@ class ParseRssTest extends \EasyRdf\TestCase
             'parse_rss.php',
             array('uri' => 'http://planetrdf.com/index.rdf')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<p>Channel: <a href="http://planetrdf.com/">Planet RDF</a></p>',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<p>Description: It's triples all the way down</p>",
             $output
         );
-        $this->assertContains('<li><a href="https://', $output);
-        $this->assertContains('</a></li>', $output);
+        $this->assertStringContainsString('<li><a href="https://', $output);
+        $this->assertStringContainsString('</a></li>', $output);
     }
 }

--- a/test/examples/SerialiseTest.php
+++ b/test/examples/SerialiseTest.php
@@ -46,8 +46,8 @@ class SerialiseTest extends \EasyRdf\TestCase
             'serialise.php',
             array('format' => 'ntriples')
         );
-        $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
+        $this->assertStringContainsString(
             '&lt;http://www.example.com/joe#me&gt; '.
             '&lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#type&gt; '.
             '&lt;http://xmlns.com/foaf/0.1/Person&gt; .',
@@ -61,8 +61,8 @@ class SerialiseTest extends \EasyRdf\TestCase
             'serialise.php',
             array('format' => 'rdfxml')
         );
-        $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
+        $this->assertStringContainsString(
             '&lt;foaf:Person rdf:about=&quot;http://www.example.com/joe#me&quot;&gt;',
             $output
         );
@@ -74,7 +74,7 @@ class SerialiseTest extends \EasyRdf\TestCase
             'serialise.php',
             array('format' => 'php')
         );
-        $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
-        $this->assertContains("'value' =&gt; 'http://xmlns.com/foaf/0.1/Person',", $output);
+        $this->assertStringContainsString('<title>EasyRdf Serialiser Example</title>', $output);
+        $this->assertStringContainsString("'value' =&gt; 'http://xmlns.com/foaf/0.1/Person',", $output);
     }
 }

--- a/test/examples/SparqlqueryformTest.php
+++ b/test/examples/SparqlqueryformTest.php
@@ -43,9 +43,9 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('sparql_queryform.php');
-        $this->assertContains('<title>EasyRdf SPARQL Query Form</title>', $output);
-        $this->assertContains('<h1>EasyRdf SPARQL Query Form</h1>', $output);
-        $this->assertContains('PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;', $output);
+        $this->assertStringContainsString('<title>EasyRdf SPARQL Query Form</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf SPARQL Query Form</h1>', $output);
+        $this->assertStringContainsString('PREFIX foaf: &lt;http://xmlns.com/foaf/0.1/&gt;', $output);
     }
 
     public function testDbpediaCountries()
@@ -59,13 +59,13 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
                     'SELECT * WHERE {'.
                     '  ?country rdf:type dbo:Country . '.
                     '  ?country rdfs:label ?label .'.
-                    '  ?country dct:subject dbc:Member_states_of_the_United_Nations .'.
+                    '  ?country dct:subject dbc:Current_member_states_of_the_United_Nations .'.
                     '  FILTER ( lang(?label) = "en" ) '.
                     '} ORDER BY ?label LIMIT 100'
             )
         );
-        $this->assertContains('>http://dbpedia.org/resource/China</a>', $output);
-        $this->assertContains('>&quot;China&quot;@en</span>', $output);
+        $this->assertStringContainsString('>http://dbpedia.org/resource/China</a>', $output);
+        $this->assertStringContainsString('>&quot;China&quot;@en</span>', $output);
     }
 
     public function testDbpediaCountriesText()
@@ -79,14 +79,14 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
                     'SELECT * WHERE {'.
                     '  ?country rdf:type dbo:Country . '.
                     '  ?country rdfs:label ?label .'.
-                    '  ?country dct:subject dbc:Member_states_of_the_United_Nations .'.
+                    '  ?country dct:subject dbc:Current_member_states_of_the_United_Nations .'.
                     '  FILTER ( lang(?label) = "en" ) '.
                     '} ORDER BY ?label LIMIT 100',
                 'text' => 1
             )
         );
 
-        $this->assertContains('| http://dbpedia.org/resource/China', $output);
-        $this->assertContains('| &quot;China&quot;@en', $output);
+        $this->assertStringContainsString('| http://dbpedia.org/resource/China', $output);
+        $this->assertStringContainsString('| &quot;China&quot;@en', $output);
     }
 }

--- a/test/examples/UkpostcodeTest.php
+++ b/test/examples/UkpostcodeTest.php
@@ -43,8 +43,8 @@ class UkpostcodeTest extends \EasyRdf\TestCase
     public function testNoParams()
     {
         $output = executeExample('uk_postcode.php');
-        $this->assertContains('<title>EasyRdf UK Postcode Resolver</title>', $output);
-        $this->assertContains('<h1>EasyRdf UK Postcode Resolver</h1>', $output);
+        $this->assertStringContainsString('<title>EasyRdf UK Postcode Resolver</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf UK Postcode Resolver</h1>', $output);
     }
 
     public function testW1A1AA()
@@ -53,13 +53,12 @@ class UkpostcodeTest extends \EasyRdf\TestCase
             'uk_postcode.php',
             array('postcode' => 'W1A 1AA')
         );
-        $this->assertContains('<tr><th>Longitude:</th><td>-0.143799</td></tr>', $output);
-        $this->assertContains('<tr><th>Latitude:</th><td>51.518561</td></tr>', $output);
-        $this->assertContains('<tr><th>Easting:</th><td>528887.0</td></tr>', $output);
-        $this->assertContains('<tr><th>Northing:</th><td>181593.0</td></tr>', $output);
-        $this->assertContains('<tr><th>District:</th><td>City of Westminster</td></tr>', $output);
-        $this->assertContains('<tr><th>Ward:</th><td>West End</td></tr>', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<tr><th>Longitude:</th><td>-0.143799</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Latitude:</th><td>51.518561</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Easting:</th><td>528887.0</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>Northing:</th><td>181593.0</td></tr>', $output);
+        $this->assertStringContainsString('<tr><th>District:</th><td>City of Westminster</td></tr>', $output);
+        $this->assertStringContainsString(
             "src='https://www.openlinkmap.org/small.php?lat=51.518561&lon=-0.143799&zoom=14'",
             $output
         );

--- a/test/examples/WikidataVillagesTest.php
+++ b/test/examples/WikidataVillagesTest.php
@@ -43,10 +43,10 @@ class VillagesTest extends \EasyRdf\TestCase
     public function testIndex()
     {
         $output = executeExample('wikidata_villages.php');
-        $this->assertContains('<title>EasyRdf Village Info Example</title>', $output);
-        $this->assertContains('<h1>EasyRdf Village Info Example</h1>', $output);
-        $this->assertContains('?id=Q33980">Ceres</a></li>', $output);
-        $this->assertContains('?id=Q1011990">Strathkinness</a></li>', $output);
+        $this->assertStringContainsString('<title>EasyRdf Village Info Example</title>', $output);
+        $this->assertStringContainsString('<h1>EasyRdf Village Info Example</h1>', $output);
+        $this->assertStringContainsString('?id=Q33980">Ceres</a></li>', $output);
+        $this->assertStringContainsString('?id=Q1011990">Strathkinness</a></li>', $output);
     }
 
     public function testCeres()
@@ -55,16 +55,16 @@ class VillagesTest extends \EasyRdf\TestCase
             'wikidata_villages.php',
             array('id' => 'Q33980')
         );
-        $this->assertContains('<h2>Ceres</h2>', $output);
-        $this->assertContains('<p>village in Fife, Scotland', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('<h2>Ceres</h2>', $output);
+        $this->assertStringContainsString('<p>village in Fife, Scotland', $output);
+        $this->assertStringContainsString(
             '<img src="http://commons.wikimedia.org/wiki/Special:FilePath/Ceres%20in%20Fife.JPG"',
             $output
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "src='http://www.openlinkmap.org/small.php?lat=56.29205&lon=-2.971445",
             $output
         );
-        $this->assertContains('<a href="https://en.wikipedia.org/wiki/Ceres,_Fife">', $output);
+        $this->assertStringContainsString('<a href="https://en.wikipedia.org/wiki/Ceres,_Fife">', $output);
     }
 }


### PR DESCRIPTION
This pull request is a systematic approach to the EasyRdf PHP 8.1 compatibility issues. Instead of depending solely on tests, a static code analyzer [phpstan](https://phpstan.org/) has been used to detect all incompatibilities.

As a side effect fixes for other problems reported by the code analyzer have been provided like making docstring type hints in line with the code, resolving broken inheritance of ARC/JSON and RdfPhp serialisers/parsers, declaring few undeclared class properties, etc.

Last but not least examples and example tests have been fixed both for PHP 8.0/8.1 incompatibilities and for changes in the data they rely upon so that `make test` reports no errors nor warnings.

It's worth noting the adjustments required for the PHP 8.1 compatibility introduce backward-incompatible API changes. `ArrayAccess` interface [`offsetSet()`](https://www.php.net/manual/en/arrayaccess.offsetset.php) and [`offsetUnset()`](https://www.php.net/manual/en/arrayaccess.offsetunset.php) methods must return `void` while in EasyRdf they sometimes returned a value. I don't expect it to affect many users and this behavior hasn't been covered by tests but it means an EasyRdf release incorporating this pull request will require EasyRdf major version bump.