### PR TITLE
Prevent RdfNamespace::splitUri() from generating `prefix:#fragment` qnames

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
 
 # workaround for error during install
 # see: https://github.com/geerlingguy/ansible-role-java/issues/64
-RUN mkdir /usr/share/man/man1/
+RUN mkdir -p /usr/share/man/man1/
 RUN apt-get install -y openjdk-11-jre
 
 RUN docker-php-ext-install intl zip && docker-php-ext-enable intl zip

--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -350,9 +350,8 @@ class RdfNamespace
             }
 
             $local_part = substr($uri, strlen($long));
-
-            if (strpos($local_part, '/') !== false) {
-                // we can't have '/' in local part
+            if (strpos($local_part, '/') !== false || strpos($local_part, '#') !== false) {
+                // we can't have '/' or '#' in local part
                 continue;
             }
 

--- a/test/EasyRdf/NamespaceTest.php
+++ b/test/EasyRdf/NamespaceTest.php
@@ -677,4 +677,16 @@ class NamespaceTest extends TestCase
         $this->assertSame('ex:foo', RdfNamespace::shorten('http://example.org/foo'));
         $this->assertNull(RdfNamespace::shorten('http://example.org/bar/baz'));
     }
+
+    /**
+     * URIs with fragments can only be shortened where the '#' character
+     * is part of the prefix - `prefix:[...]#fragment` is not a valid result
+     */
+    public function testNoShortFragment()
+    {
+        RdfNamespace::set('ex', 'http://example.org/');
+
+        $this->assertNull(RdfNamespace::shorten('http://example.org/foo#bar'));
+        $this->assertNull(RdfNamespace::shorten('http://example.org/#quack'));
+    }
 }

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -648,13 +648,26 @@ class TurtleTest extends TestCase
     public function testSerialiseShortenableResource()
     {
         RdfNamespace::set("example", 'http://example.com/');
-        $joe = $this->graph->resource('http://example.com/joe#me');
+        $joe = $this->graph->resource('http://example.com/joe');
         $joe->add('rdf:type', 'foaf:Person');
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
             "@prefix example: <http://example.com/> .\n\n".
-            "example:joe#me a \"foaf:Person\" .\n",
+            "example:joe a \"foaf:Person\" .\n",
+            $turtle
+        );
+    }
+
+    public function testSerialiseUnshortenableResource()
+    {
+        RdfNamespace::set("example", 'http://example.com/');
+        $joe = $this->graph->resource('http://example.com/joe#me');
+        $joe->add('rdf:type', 'foaf:Person');
+
+        $turtle = $this->serialiser->serialise($this->graph, 'turtle');
+        $this->assertSame(
+            "<http://example.com/joe#me> a \"foaf:Person\" .\n",
             $turtle
         );
     }


### PR DESCRIPTION
it's possible to coax EasyRdf\RdfNamespace::splitUri() into generating a qname in the form `prefix:#fragment`, which is not valid, for example by defining a namespace as `https://www.example.com/foo/` and then referring to `https://www.example.com/foo/#bar`; this fix prevents that