### PR TITLE
add cast string strtolower

### DIFF
--- a/lib/Http/Response.php
+++ b/lib/Http/Response.php
@@ -167,11 +167,11 @@ class Response
     {
         $body = $this->body;
 
-        if ('chunked' === strtolower($this->getHeader('transfer-encoding'))) {
+        if ( 'chunked' === strtolower( (string)$this->getHeader('transfer-encoding') ) ) {
             $body = self::decodeChunkedBody($body);
         }
 
-        $contentEncoding = strtolower($this->getHeader('content-encoding'));
+        $contentEncoding = strtolower( (string)$this->getHeader('content-encoding') );
 
         if ('gzip' === $contentEncoding) {
             $body = self::decodeGzip($body);


### PR DESCRIPTION
fixes annoying error

`
strtolower(): Passing null to parameter #1 ($string) of type string is deprecated`